### PR TITLE
[feat] 로그인 기능 구현 및 Jwt 토큰 발행 및 인증 로직 추가

### DIFF
--- a/jamanchu/build.gradle
+++ b/jamanchu/build.gradle
@@ -24,14 +24,31 @@ repositories {
 }
 
 dependencies {
+
+	// String Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	testImplementation 'org.springframework.security:spring-security-test'
+
+	// Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Test
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/jamanchu/build.gradle
+++ b/jamanchu/build.gradle
@@ -25,15 +25,33 @@ repositories {
 
 dependencies {
 
+	// Spring Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	testImplementation 'org.springframework.security:spring-security-test'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Test
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/JwtFilter.java
@@ -30,6 +30,14 @@ public class JwtFilter extends OncePerRequestFilter {
       FilterChain filterChain)
       throws ServletException, IOException {
 
+    String requestURI = request.getRequestURI();
+
+    // 인증이 필요 없는 경로
+    if (isExcludedPath(requestURI)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
     String accessToken = request.getHeader("access");
 
     if (accessToken == null) {
@@ -115,6 +123,12 @@ public class JwtFilter extends OncePerRequestFilter {
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
     response.getWriter().write("인증 토큰이 만료되었습니다. 다시 로그인해 주세요.");
+  }
+
+  private boolean isExcludedPath(String requestURI) {
+    return requestURI.equals("/")
+        || requestURI.equals("/login")
+        || requestURI.equals("/api/v1/user/signup");
   }
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/JwtFilter.java
@@ -1,0 +1,120 @@
+package com.recipe.jamanchu.auth;
+
+import com.recipe.jamanchu.entity.UserEntity;
+import com.recipe.jamanchu.model.dto.request.UserDetailsDTO;
+import com.recipe.jamanchu.model.type.UserRole;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+  private final JwtUtil jwtUtil;
+  private final Logger logger = LoggerFactory.getLogger(JwtFilter.class);
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String accessToken = request.getHeader("access");
+
+    if (accessToken == null) {
+      logger.info("Access token is null");
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    try {
+      // access 토큰이 만료가 되지 않은 경우
+      jwtUtil.isExpired(accessToken);
+
+      setAuthenticationFromToken(response, accessToken);
+    } catch (ExpiredJwtException e) {
+      expiredAccessToken(request, response);
+      return;
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private void setAuthenticationFromToken(HttpServletResponse response, String token) {
+    response.addHeader("access", token);
+
+    Authentication authToken = getAuthToken(token);
+    SecurityContextHolder.getContext().setAuthentication(authToken);
+  }
+
+
+  // access 토큰이 만료되었을 경우 refresh 토큰 검증 후 재 발급
+  private void expiredAccessToken(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    String refreshToken = getRefreshTokenFromCookies(request);
+
+    if (refreshToken == null) {
+      setResponse(response);
+      return;
+    }
+
+    try {
+      jwtUtil.isExpired(refreshToken);
+      String newAccessToken = createNewAccessToken(refreshToken);
+
+      setAuthenticationFromToken(response, newAccessToken);
+    } catch (ExpiredJwtException e) {
+      setResponse(response);
+    }
+  }
+
+  // refresh 토큰 반환
+  private String getRefreshTokenFromCookies(HttpServletRequest request) {
+    return Arrays.stream(request.getCookies())
+        .filter(cookie -> "refresh".equals(cookie.getName()))
+        .map(Cookie::getValue)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private Authentication getAuthToken(String token) {
+    Long userId = jwtUtil.getUserId(token);
+    UserRole role = jwtUtil.getRole(token);
+
+    UserEntity user = UserEntity.builder()
+        .userId(userId)
+        .role(UserRole.USER)
+        .build();
+
+    UserDetailsDTO userDetails = new UserDetailsDTO(user);
+    return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+  }
+
+  // access 토큰 재발급
+  private String createNewAccessToken(String refreshToken) {
+    Long userId = jwtUtil.getUserId(refreshToken);
+    UserRole role = jwtUtil.getRole(refreshToken);
+
+    return jwtUtil.createJwt("access", userId, role);
+  }
+
+  // 오류 메세지 전송
+  private void setResponse(HttpServletResponse response) throws IOException {
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write("인증 토큰이 만료되었습니다. 다시 로그인해 주세요.");
+  }
+}
+

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/JwtUtil.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/JwtUtil.java
@@ -1,0 +1,69 @@
+package com.recipe.jamanchu.auth;
+
+import com.recipe.jamanchu.model.type.UserRole;
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+  private final SecretKey secretKey;
+  public static final long ACCESS_TOKEN_EXPIRE_TIME = 10 * 60 * 1000L;  // 10분
+  public static final long REFRESH_TOKEN_EXPIRE_TIME = 24 * 60 * 60 * 1000L;  // 24시간
+
+  public JwtUtil(@Value("${spring.jwt.secret.key}")String secret) {
+
+    secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+        Jwts.SIG.HS256.key().build().getAlgorithm());
+  }
+
+  public Long getUserId(String token) {
+    return Jwts.parser().verifyWith(secretKey).build()
+        .parseSignedClaims(token)
+        .getPayload()
+        .get("userId", Long.class);
+  }
+
+  public UserRole getRole(String token) {
+    return Jwts.parser().verifyWith(secretKey).build()
+        .parseSignedClaims(token)
+        .getPayload()
+        .get("role", UserRole.class);
+  }
+
+  public String getType(String token) {
+    return Jwts.parser().verifyWith(secretKey).build()
+        .parseSignedClaims(token)
+        .getPayload()
+        .get("type", String.class);
+  }
+
+  public void isExpired(String token) {
+    Jwts.parser().verifyWith(secretKey).build()
+        .parseSignedClaims(token)
+        .getPayload()
+        .getExpiration();
+  }
+
+
+  public String createJwt(String type, Long userId, UserRole role) {
+    long expirationTime = "access".equals(type)
+        ? ACCESS_TOKEN_EXPIRE_TIME
+        : REFRESH_TOKEN_EXPIRE_TIME;
+
+    return Jwts.builder()
+        .claim("type", type)
+        .claim("userId", userId)
+        .claim("role", role)
+        .notBefore(new Date(System.currentTimeMillis()))
+        .expiration(new Date(System.currentTimeMillis() + expirationTime))
+        .signWith(secretKey)
+        .compact();
+  }
+}
+

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/LoginFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/LoginFilter.java
@@ -82,10 +82,13 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     response.setCharacterEncoding("UTF-8");
 
     UserEntity user = userRepository.findByEmail(request.getParameter("email"))
-        .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
+        .orElseGet(() -> null);
 
     String enPassword = passwordEncoder.encode(request.getParameter("password"));
-    if (!enPassword.equals(user.getPassword())) {
+
+    if (user == null) {
+      response.getWriter().write("이미 존재하는 아이디 입니다.");
+    } else if (!enPassword.equals(user.getPassword())) {
       response.getWriter().write("비밀번호를 다시 입력해주세요");
     }
   }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/LoginFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/LoginFilter.java
@@ -1,6 +1,7 @@
 package com.recipe.jamanchu.auth;
 
 import com.recipe.jamanchu.entity.UserEntity;
+import com.recipe.jamanchu.exceptions.exception.UserNotFoundException;
 import com.recipe.jamanchu.model.dto.request.UserDetailsDTO;
 import com.recipe.jamanchu.repository.UserRepository;
 import jakarta.servlet.FilterChain;
@@ -15,7 +16,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -52,7 +52,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     UserDetailsDTO userDetails = (UserDetailsDTO) authentication.getPrincipal();
 
     UserEntity user = userRepository.findByEmail(userDetails.getUsername())
-        .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
+        .orElseThrow(UserNotFoundException::new);
 
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/LoginFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/LoginFilter.java
@@ -1,0 +1,93 @@
+package com.recipe.jamanchu.auth;
+
+import com.recipe.jamanchu.entity.UserEntity;
+import com.recipe.jamanchu.model.dto.request.UserDetailsDTO;
+import com.recipe.jamanchu.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+  private final AuthenticationManager authenticationManager;
+  private final BCryptPasswordEncoder passwordEncoder;
+  private final JwtUtil jwtUtil;
+  private final UserRepository userRepository;
+  public final Logger logger = LoggerFactory.getLogger(LoginFilter.class);
+
+  @Override
+  public Authentication attemptAuthentication(HttpServletRequest request,
+      HttpServletResponse response) throws AuthenticationException {
+
+    String email = request.getParameter("email");
+    String password = obtainPassword(request);
+
+    logger.info("email = {}", request.getParameter("email"));
+    logger.info("password = {}", obtainPassword(request));
+
+    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+        email, password, null);
+
+    return authenticationManager.authenticate(authToken);
+  }
+
+
+  @Override
+  protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+      FilterChain chain, Authentication authentication) throws IOException {
+
+    UserDetailsDTO userDetails = (UserDetailsDTO) authentication.getPrincipal();
+
+    UserEntity user = userRepository.findByEmail(userDetails.getUsername())
+        .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
+
+    String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
+    String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
+
+    response.addHeader("access", access);
+    response.addCookie(createCookie(refresh));
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write("로그인 성공");
+  }
+
+  private Cookie createCookie(String value) {
+    Cookie cookie = new Cookie("refresh", value);
+    cookie.setMaxAge(24 * 60 * 60);
+    cookie.setHttpOnly(true);
+
+    return cookie;
+  }
+
+  @Override
+  protected void unsuccessfulAuthentication(HttpServletRequest request,
+      HttpServletResponse response, AuthenticationException failed) throws IOException {
+
+    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+
+    UserEntity user = userRepository.findByEmail(request.getParameter("email"))
+        .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
+
+    String enPassword = passwordEncoder.encode(request.getParameter("password"));
+    if (!enPassword.equals(user.getPassword())) {
+      response.getWriter().write("비밀번호를 다시 입력해주세요");
+    }
+  }
+}
+

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -1,33 +1,59 @@
 package com.recipe.jamanchu.config;
 
+import com.recipe.jamanchu.auth.JwtFilter;
+import com.recipe.jamanchu.auth.JwtUtil;
+import com.recipe.jamanchu.auth.LoginFilter;
+import com.recipe.jamanchu.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
 
+  private final AuthenticationConfiguration authenticationConfiguration;
   private final BCryptPasswordEncoder passwordEncoder;
+  private final JwtUtil jwtUtil;
+  private final UserRepository userRepository;
+
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+
+    return configuration.getAuthenticationManager();
+  }
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
     http
         .csrf(AbstractHttpConfigurer::disable);
-
     http
         .httpBasic(AbstractHttpConfigurer::disable);
-
     http
         .authorizeHttpRequests(auth -> auth
-            .anyRequest().permitAll());
+            .requestMatchers("/", "/api/v1/user/signup", "login").permitAll()
+            .anyRequest().authenticated()
+        );
+
+    http
+        .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);
+    http
+        .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration)
+            ,passwordEncoder, jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class);
+    http
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
     return http.build();
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -39,6 +39,8 @@ public class SecurityConfig {
     http
         .csrf(AbstractHttpConfigurer::disable);
     http
+        .formLogin(AbstractHttpConfigurer::disable);
+    http
         .httpBasic(AbstractHttpConfigurer::disable);
     http
         .authorizeHttpRequests(auth -> auth

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
@@ -21,5 +21,4 @@ public class UserController {
 
     return ResponseEntity.ok(userService.signup(signupDTO));
   }
-
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/UserEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/UserEntity.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Entity
 @Table(name = "user")
-public class UserEntity {
+public class UserEntity extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/ExceptionStatus.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/ExceptionStatus.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ExceptionStatus {
 
+  USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 사용자를 찾을 수 없습니다."),
   DUPLICATE_EMAIL(HttpStatus.UNAUTHORIZED, "이미 존재하는 이메일 입니다."),
   DUPLICATE_NICKNAME(HttpStatus.UNAUTHORIZED, "이미 존재하는 닉네임 입니다.");
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/exception/UserNotFoundException.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.recipe.jamanchu.exceptions.exception;
+
+import com.recipe.jamanchu.exceptions.ExceptionStatus;
+
+public class UserNotFoundException extends GlobalException{
+
+  public UserNotFoundException() {
+
+    super(ExceptionStatus.USER_NOT_FOUND);
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/UserDetailsDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/UserDetailsDTO.java
@@ -1,0 +1,67 @@
+package com.recipe.jamanchu.model.dto.request;
+
+import com.recipe.jamanchu.entity.UserEntity;
+import java.util.ArrayList;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class UserDetailsDTO implements UserDetails {
+  private final UserEntity userEntity;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+
+    Collection<GrantedAuthority> collection = new ArrayList<>();
+
+    collection.add(new GrantedAuthority() {
+
+      @Override
+      public String getAuthority() {
+
+        return userEntity.getRole().toString();
+      }
+    });
+
+    return collection;
+  }
+
+  @Override
+  public String getPassword() {
+
+    return userEntity.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+
+    return userEntity.getEmail();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+
+    return true;
+  }
+}
+

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/UserRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.recipe.jamanchu.repository;
 
 import com.recipe.jamanchu.entity.UserEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
   boolean existsByEmail(String email);
 
   boolean existsByNickname(String nickname);
+
+  Optional<UserEntity> findByEmail(String username);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.recipe.jamanchu.service.impl;
 import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedEmailException;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedNicknameException;
+import com.recipe.jamanchu.exceptions.exception.UserNotFoundException;
 import com.recipe.jamanchu.model.dto.request.SignupDTO;
 import com.recipe.jamanchu.model.dto.request.UserDetailsDTO;
 import com.recipe.jamanchu.model.dto.response.UserResponse;
@@ -45,9 +46,9 @@ public class UserServiceImpl implements UserService, UserDetailsService {
   }
 
   @Override
-  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+  public UserDetails loadUserByUsername(String username) {
     UserEntity user = userRepository.findByEmail(username)
-        .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
+        .orElseThrow(UserNotFoundException::new);
 
     return new UserDetailsDTO(user);
   }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -4,17 +4,21 @@ import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedEmailException;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedNicknameException;
 import com.recipe.jamanchu.model.dto.request.SignupDTO;
+import com.recipe.jamanchu.model.dto.request.UserDetailsDTO;
 import com.recipe.jamanchu.model.dto.response.UserResponse;
 import com.recipe.jamanchu.model.type.UserRole;
 import com.recipe.jamanchu.repository.UserRepository;
 import com.recipe.jamanchu.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class UserServiceImpl implements UserService {
+public class UserServiceImpl implements UserService, UserDetailsService {
 
   private final UserRepository userRepository;
   private final BCryptPasswordEncoder passwordEncoder;
@@ -38,5 +42,13 @@ public class UserServiceImpl implements UserService {
         .build());
 
     return UserResponse.SUCCESS_SIGNUP;
+  }
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    UserEntity user = userRepository.findByEmail(username)
+        .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
+
+    return new UserDetailsDTO(user);
   }
 }

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/LoginFilterTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/LoginFilterTest.java
@@ -1,7 +1,6 @@
 package com.recipe.jamanchu.auth;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -17,16 +16,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -39,9 +34,6 @@ class LoginFilterTest {
 
   @Mock
   private BCryptPasswordEncoder passwordEncoder;
-
-  @Mock
-  private AuthenticationManager authenticationManager;
 
   @Mock
   private JwtUtil jwtUtil;
@@ -67,7 +59,7 @@ class LoginFilterTest {
 
   @Test
   @DisplayName("로그인 성공")
-  void testSuccessfulAuthentication() throws Exception {
+  void login() throws Exception {
     // given
     String email = "test@example.com";
     String password = "password";
@@ -107,7 +99,7 @@ class LoginFilterTest {
   @DisplayName("로그인 실패: 사용자 없음")
   void testUnsuccessfulAuthenticationUserNotFound() throws IOException {
     // Given
-    String email = "nonexistent@example.com";
+    String email = "test@example.com";
     String password = "password";
 
     when(request.getParameter("email")).thenReturn(email);
@@ -132,13 +124,15 @@ class LoginFilterTest {
   void testUnsuccessfulAuthenticationIncorrectPassword() throws IOException {
     // Given
     String email = "test@example.com";
-    String password = "wrongpassword";
+    String password = "1234";
     String encodedPassword = "encodedWrongPassword";
-    String storedPassword = "encodedCorrectPassword";
 
-    UserEntity user = new UserEntity();
-    user.setEmail(email);
-    user.setPassword(storedPassword);
+    UserEntity user = UserEntity.builder()
+        .userId(1L)
+        .email(email)
+        .password(passwordEncoder.encode(password))
+        .role(UserRole.USER)
+        .build();
 
     when(request.getParameter("email")).thenReturn(email);
     when(request.getParameter("password")).thenReturn(password);
@@ -159,4 +153,3 @@ class LoginFilterTest {
   }
 }
 
-}

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/LoginFilterTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/LoginFilterTest.java
@@ -97,8 +97,8 @@ class LoginFilterTest {
 
   @Test
   @DisplayName("로그인 실패: 사용자 없음")
-  void testUnsuccessfulAuthenticationUserNotFound() throws IOException {
-    // Given
+  void loginUserNotFound() throws IOException {
+    // given
     String email = "test@example.com";
     String password = "password";
 
@@ -109,10 +109,10 @@ class LoginFilterTest {
     PrintWriter writer = mock(PrintWriter.class);
     when(response.getWriter()).thenReturn(writer);
 
-    // When
+    // when
     loginFilter.unsuccessfulAuthentication(request, response, authException);
 
-    // Then
+    // then
     verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
     verify(response).setContentType("application/json");
     verify(response).setCharacterEncoding("UTF-8");
@@ -121,8 +121,8 @@ class LoginFilterTest {
 
   @Test
   @DisplayName("로그인 실패: 비밀번호 불일치")
-  void testUnsuccessfulAuthenticationIncorrectPassword() throws IOException {
-    // Given
+  void loginValidatePassword() throws IOException {
+    // given
     String email = "test@example.com";
     String password = "1234";
     String encodedPassword = "encodedWrongPassword";
@@ -142,10 +142,10 @@ class LoginFilterTest {
     PrintWriter writer = mock(PrintWriter.class);
     when(response.getWriter()).thenReturn(writer);
 
-    // When
+    // when
     loginFilter.unsuccessfulAuthentication(request, response, authException);
 
-    // Then
+    // then
     verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
     verify(response).setContentType("application/json");
     verify(response).setCharacterEncoding("UTF-8");

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/LoginFilterTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/LoginFilterTest.java
@@ -1,0 +1,162 @@
+package com.recipe.jamanchu.auth;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.recipe.jamanchu.entity.UserEntity;
+import com.recipe.jamanchu.model.dto.request.UserDetailsDTO;
+import com.recipe.jamanchu.model.type.UserRole;
+import com.recipe.jamanchu.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class LoginFilterTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private BCryptPasswordEncoder passwordEncoder;
+
+  @Mock
+  private AuthenticationManager authenticationManager;
+
+  @Mock
+  private JwtUtil jwtUtil;
+
+  @InjectMocks
+  private LoginFilter loginFilter;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private FilterChain chain;
+
+  @Mock
+  private Authentication authentication;
+
+  @Mock
+  private AuthenticationException authException;
+
+
+  @Test
+  @DisplayName("로그인 성공")
+  void testSuccessfulAuthentication() throws Exception {
+    // given
+    String email = "test@example.com";
+    String password = "password";
+    String accessToken = "accessToken";
+    String refreshToken = "refreshToken";
+
+    UserEntity user = UserEntity.builder()
+        .userId(1L)
+        .email(email)
+        .password(passwordEncoder.encode(password))
+        .role(UserRole.USER)
+        .build();
+
+    UserDetailsDTO userDetails = new UserDetailsDTO(user);
+
+    when(authentication.getPrincipal()).thenReturn(userDetails);
+    when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+    when(jwtUtil.createJwt("access", user.getUserId(), user.getRole())).thenReturn("accessToken");
+    when(jwtUtil.createJwt("refresh", user.getUserId(), user.getRole())).thenReturn(refreshToken);
+
+    PrintWriter writer = mock(PrintWriter.class);
+    when(response.getWriter()).thenReturn(writer);
+
+    // when
+    loginFilter.successfulAuthentication(request, response, chain, authentication);
+
+    // then
+    verify(response).addHeader("access", accessToken);
+    verify(response).addCookie(any(Cookie.class));
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+    verify(response).setContentType("application/json");
+    verify(response).setCharacterEncoding("UTF-8");
+    verify(writer).write("로그인 성공");
+  }
+
+  @Test
+  @DisplayName("로그인 실패: 사용자 없음")
+  void testUnsuccessfulAuthenticationUserNotFound() throws IOException {
+    // Given
+    String email = "nonexistent@example.com";
+    String password = "password";
+
+    when(request.getParameter("email")).thenReturn(email);
+    when(request.getParameter("password")).thenReturn(password);
+    when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+    PrintWriter writer = mock(PrintWriter.class);
+    when(response.getWriter()).thenReturn(writer);
+
+    // When
+    loginFilter.unsuccessfulAuthentication(request, response, authException);
+
+    // Then
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    verify(response).setContentType("application/json");
+    verify(response).setCharacterEncoding("UTF-8");
+    verify(writer).write("이미 존재하는 아이디 입니다.");
+  }
+
+  @Test
+  @DisplayName("로그인 실패: 비밀번호 불일치")
+  void testUnsuccessfulAuthenticationIncorrectPassword() throws IOException {
+    // Given
+    String email = "test@example.com";
+    String password = "wrongpassword";
+    String encodedPassword = "encodedWrongPassword";
+    String storedPassword = "encodedCorrectPassword";
+
+    UserEntity user = new UserEntity();
+    user.setEmail(email);
+    user.setPassword(storedPassword);
+
+    when(request.getParameter("email")).thenReturn(email);
+    when(request.getParameter("password")).thenReturn(password);
+    when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+    when(passwordEncoder.encode(password)).thenReturn(encodedPassword);
+
+    PrintWriter writer = mock(PrintWriter.class);
+    when(response.getWriter()).thenReturn(writer);
+
+    // When
+    loginFilter.unsuccessfulAuthentication(request, response, authException);
+
+    // Then
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    verify(response).setContentType("application/json");
+    verify(response).setCharacterEncoding("UTF-8");
+    verify(writer).write("비밀번호를 다시 입력해주세요");
+  }
+}
+
+}

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -2,7 +2,7 @@ package com.recipe.jamanchu.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 
 import com.recipe.jamanchu.exceptions.exception.DuplicatedEmailException;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedNicknameException;
@@ -36,8 +36,8 @@ class UserServiceImplTest {
     // given
     SignupDTO signup = new SignupDTO("dlrkdhsoff@gmail.com", "1234", "nickname");
 
-    given(userRepository.existsByEmail(signup.getEmail())).willReturn(false);
-    given(userRepository.existsByNickname(signup.getNickname())).willReturn(false);
+    when(userRepository.existsByEmail(signup.getEmail())).thenReturn(false);
+    when(userRepository.existsByNickname(signup.getNickname())).thenReturn(false);
 
     // when
     UserResponse result = userServiceimpl.signup(signup);
@@ -55,7 +55,7 @@ class UserServiceImplTest {
     UserResponse result = userServiceimpl.signup(signup);
 
     SignupDTO newUser = new SignupDTO("dlrkdhsoff@gmail.com", "1234", "nickname");
-    given(userRepository.existsByEmail(signup.getEmail())).willReturn(true);
+    when(userRepository.existsByEmail(signup.getEmail())).thenReturn(true);
 
     // when then
     assertThrows(DuplicatedEmailException.class, () -> userServiceimpl.signup(newUser));
@@ -70,7 +70,7 @@ class UserServiceImplTest {
     UserResponse result = userServiceimpl.signup(signup);
 
     SignupDTO newUser = new SignupDTO("newEmail@gmail.com", "1234", "nickname");
-    given(userRepository.existsByNickname(signup.getNickname())).willReturn(true);
+    when(userRepository.existsByNickname(signup.getNickname())).thenReturn(true);
 
     // when then
     assertThrows(DuplicatedNicknameException.class, () -> userServiceimpl.signup(newUser));


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
로그인 기능을 구현하였습니다.

 - 의존성 추가
   - implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
   - implementation 'io.jsonwebtoken:jjwt-impl:0.12.5'
   - implementation 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 - 구현한 내용 요약
 
   - 구현한 클래스
     - LoginFilter: 로그인 시 인증 및 JWT 토큰 발급을 처리하는 필터 클래스.
        - 사용자의 이메일과 비밀번호로 Authentication 객체를 생성하여 인증을 시도.
        - 인증 성공 시 JWT 토큰을 생성하고, 응답 헤더에 access-token을 추가하며, 쿠키에 refresh-token을 저장.
        - 인증 실패 시 사용자에게 실패 원인을 Response로 전달.
        
     - JwtFilter: 요청이 들어올 때마다 JWT 토큰을 검증하고, 유효한 경우 인증 정보를 설정하는 필터 클래스.
        - 요청의 헤더에 포함된 access-token을 확인하고 해당 토큰의 유효성 검증.
        - access-token이 만료된 경우, refresh-token을 사용하여 새로운 access-token 발급.
        - 인증이 필요한 경로와 그렇지 않은 경로를 구분하여, 인증이 필요한 경로만 토큰 검증.
     - JwtUtil: JWT 토큰을 생성하고 검증하는 클래스.
        - userId, role, 토큰 타입(access, refresh)을 포함한 JWT 토큰을 생성.
        - 토큰의 유효성을 검증하고, 만료 시간을 확인.
        - JWT 토큰에서 사용자 ID, 역할, 토큰 타입 등의 정보를 추출.
     - UserDetailsDTO: Spring Security에서 사용자의 인증 정보를 다루기 위한 DTO 클래스.
        - UserEntity를 기반으로 UserDetails를 구현하여 인증에 필요한 정보를 제공.
        
   - 수정한 클래스
      - SecurityConfig: JwtFilter와 LoginFilter 클래스를 필터 체인에 추가.
      
         - 로그인 요청 시 LoginFilter를 통해 인증을 처리.
         - 인증 이후의 요청에 대해서는 JwtFilter를 통해 토큰을 검증.
      - UserServiceImpl : loadUserByUsername 메서드를 추가.
        - 이메일을 이용하여 데이터베이스에서 사용자 정보를 조회. 
     - UserRepository: findByEmail 메서드를 추가.
        - 이메일로 사용자 정보를 조회하는 메서드. 
   - 단위 테스트
      - LoginFilterTest : 로그인 기능에 대한 테스트 클래스.
     
         - login_Success: 로그인 성공
         - login_UserNotFound: 로그인 실패 - 존재하지 않는 사용자
         - login_InvalidPassword: 로그인 실패 - 비밀번호 불일치
## 스크린샷

## 주의사항

Closes #9 
