### PR TITLE
[feat] OAuth2 (카카오) 로그인 기능 구현

### DIFF
--- a/jamanchu/build.gradle
+++ b/jamanchu/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	// Mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -1,4 +1,4 @@
-package com.recipe.jamanchu.auth;
+package com.recipe.jamanchu.auth.jwt;
 
 import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.model.dto.request.UserDetailsDTO;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtUtil.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtUtil.java
@@ -1,4 +1,4 @@
-package com.recipe.jamanchu.auth;
+package com.recipe.jamanchu.auth.jwt;
 
 import com.recipe.jamanchu.model.type.UserRole;
 import io.jsonwebtoken.Jwts;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/LoginFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/LoginFilter.java
@@ -1,4 +1,4 @@
-package com.recipe.jamanchu.auth;
+package com.recipe.jamanchu.auth.jwt;
 
 import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.exceptions.exception.UserNotFoundException;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/CustomOauth2UserService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/CustomOauth2UserService.java
@@ -1,0 +1,23 @@
+package com.recipe.jamanchu.auth.oauth2;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+    return new DefaultOAuth2UserService().loadUser(userRequest);
+  }
+
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/CustomOauth2UserService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/CustomOauth2UserService.java
@@ -1,7 +1,6 @@
 package com.recipe.jamanchu.auth.oauth2;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
@@ -11,7 +10,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
   @Override

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/KakaoUserDetails.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/KakaoUserDetails.java
@@ -1,0 +1,22 @@
+package com.recipe.jamanchu.auth.oauth2;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class KakaoUserDetails {
+
+  private Map<String, Object> attributes;
+
+  public String getProviderId() {
+    return attributes.get("id").toString();
+  }
+
+  public String getEmail() {
+    return (String) ((Map<?, ?>) attributes.get("kakao_account")).get("email");
+  }
+
+  public String getNickname() {
+    return (String) ((Map<?, ?>) attributes.get("properties")).get("nickname");
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2FailureHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2FailureHandler.java
@@ -1,0 +1,25 @@
+package com.recipe.jamanchu.auth.oauth2.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException {
+
+    log.error("OAuth2 인증 실패");
+    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write("인증 실패하였습니다.");
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -3,7 +3,6 @@ package com.recipe.jamanchu.auth.oauth2.handler;
 import com.recipe.jamanchu.auth.jwt.JwtUtil;
 import com.recipe.jamanchu.auth.oauth2.KakaoUserDetails;
 import com.recipe.jamanchu.entity.UserEntity;
-import com.recipe.jamanchu.exceptions.exception.DuplicatedEmailException;
 import com.recipe.jamanchu.repository.UserRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -39,11 +39,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     String email = kakaoUserDetails.getEmail();
     String nickname = kakaoUserDetails.getNickname();
 
-    if (userRepository.existsByEmail(email)) {
-      throw new DuplicatedEmailException();
-    }
-
-    UserEntity user = userRepository.findByEmail(email)
+    UserEntity user = userRepository.findByProviderId(providerId)
         .orElseGet(() -> userRepository.save(UserEntity.builder()
             .email(email)
             .password(passwordEncoder.encode(String.valueOf(Math.random() * 8)))

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -57,6 +57,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     response.setCharacterEncoding("UTF-8");
     response.getWriter().write("로그인 성공");
 
+    log.info("OAuth 로그인 성공");
     String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/api/v1/test")
         .build()
         .toUriString();

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -14,13 +14,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
   private final UserRepository userRepository;
   private final BCryptPasswordEncoder passwordEncoder;
@@ -60,6 +61,12 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
     response.getWriter().write("로그인 성공");
+
+    String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/api/v1/test")
+        .build()
+        .toUriString();
+
+    getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
 
   private Cookie createCookie(String value) {

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,72 @@
+package com.recipe.jamanchu.auth.oauth2.handler;
+
+import com.recipe.jamanchu.auth.jwt.JwtUtil;
+import com.recipe.jamanchu.auth.oauth2.KakaoUserDetails;
+import com.recipe.jamanchu.entity.UserEntity;
+import com.recipe.jamanchu.exceptions.exception.DuplicatedEmailException;
+import com.recipe.jamanchu.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+  private final UserRepository userRepository;
+  private final BCryptPasswordEncoder passwordEncoder;
+  private final JwtUtil jwtUtil;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException {
+
+    OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+    KakaoUserDetails kakaoUserDetails = new KakaoUserDetails(oAuth2User.getAttributes());
+
+    String providerId = kakaoUserDetails.getProviderId();
+    String email = kakaoUserDetails.getEmail();
+    String nickname = kakaoUserDetails.getNickname();
+
+    if (userRepository.existsByEmail(email)) {
+      throw new DuplicatedEmailException();
+    }
+
+    UserEntity user = userRepository.findByEmail(email)
+        .orElseGet(() -> userRepository.save(UserEntity.builder()
+            .email(email)
+            .password(passwordEncoder.encode(String.valueOf(Math.random() * 8)))
+            .nickname(nickname)
+            .provider("kakao")
+            .providerId(providerId)
+            .build()));
+
+    String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
+    String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
+
+    response.addHeader("access", access);
+    response.addCookie(createCookie(refresh));
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write("로그인 성공");
+  }
+
+  private Cookie createCookie(String value) {
+    Cookie cookie = new Cookie("refresh", value);
+    cookie.setMaxAge(24 * 60 * 60);
+    cookie.setHttpOnly(true);
+
+    return cookie;
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -1,8 +1,8 @@
 package com.recipe.jamanchu.config;
 
-import com.recipe.jamanchu.auth.JwtFilter;
-import com.recipe.jamanchu.auth.JwtUtil;
-import com.recipe.jamanchu.auth.LoginFilter;
+import com.recipe.jamanchu.auth.jwt.JwtFilter;
+import com.recipe.jamanchu.auth.jwt.JwtUtil;
+import com.recipe.jamanchu.auth.jwt.LoginFilter;
 import com.recipe.jamanchu.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -3,6 +3,9 @@ package com.recipe.jamanchu.config;
 import com.recipe.jamanchu.auth.jwt.JwtFilter;
 import com.recipe.jamanchu.auth.jwt.JwtUtil;
 import com.recipe.jamanchu.auth.jwt.LoginFilter;
+import com.recipe.jamanchu.auth.oauth2.CustomOauth2UserService;
+import com.recipe.jamanchu.auth.oauth2.handler.OAuth2FailureHandler;
+import com.recipe.jamanchu.auth.oauth2.handler.OAuth2SuccessHandler;
 import com.recipe.jamanchu.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +29,9 @@ public class SecurityConfig {
   private final BCryptPasswordEncoder passwordEncoder;
   private final JwtUtil jwtUtil;
   private final UserRepository userRepository;
+  private final CustomOauth2UserService customOauth2UserService;
+  private final OAuth2SuccessHandler oAuth2SuccessHandler;
+  private final OAuth2FailureHandler oAuth2FailureHandler;
 
   @Bean
   public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -47,6 +53,15 @@ public class SecurityConfig {
             .requestMatchers("/", "/api/v1/user/signup", "login").permitAll()
             .anyRequest().authenticated()
         );
+
+    http
+        .oauth2Login(oauth2Login -> oauth2Login
+            .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint
+                .userService(customOauth2UserService)
+            )
+            .successHandler(oAuth2SuccessHandler)
+            .failureHandler(oAuth2FailureHandler)
+    );
 
     http
         .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/UserEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/UserEntity.java
@@ -36,6 +36,12 @@ public class UserEntity extends BaseTimeEntity {
   @Column(name = "usr_nickname")
   private String nickname;
 
+  @Column(name = "usr_provider")
+  private String provider;
+
+  @Column(name = "usr_provider_sub")
+  private String providerId;
+
   @Enumerated(EnumType.STRING)
   private UserRole role;
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/UserRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
   boolean existsByNickname(String nickname);
 
   Optional<UserEntity> findByEmail(String username);
+
+  Optional<UserEntity> findByProviderId(String providerId);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -13,7 +13,6 @@ import com.recipe.jamanchu.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/LoginFilterTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/LoginFilterTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.recipe.jamanchu.auth.jwt.JwtUtil;
+import com.recipe.jamanchu.auth.jwt.LoginFilter;
 import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.model.dto.request.UserDetailsDTO;
 import com.recipe.jamanchu.model.type.UserRole;

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/jwt/LoginFilterTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/jwt/LoginFilterTest.java
@@ -1,12 +1,10 @@
-package com.recipe.jamanchu.auth;
+package com.recipe.jamanchu.auth.jwt;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.recipe.jamanchu.auth.jwt.JwtUtil;
-import com.recipe.jamanchu.auth.jwt.LoginFilter;
 import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.model.dto.request.UserDetailsDTO;
 import com.recipe.jamanchu.model.type.UserRole;

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2FailureHandlerTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2FailureHandlerTest.java
@@ -1,0 +1,50 @@
+package com.recipe.jamanchu.auth.oauth2.handler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.AuthenticationException;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2FailureHandlerTest {
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private AuthenticationException exception;
+
+  @InjectMocks
+  private OAuth2FailureHandler oAuth2FailureHandler;
+
+  @Test
+  @DisplayName("OAuth2 인증 실패 처리 테스트")
+  void oAuthLoginFailed() throws IOException {
+    // Given
+    PrintWriter writer = mock(PrintWriter.class);
+    when(response.getWriter()).thenReturn(writer);
+
+    // When
+    oAuth2FailureHandler.onAuthenticationFailure(request, response, exception);
+
+    // Then
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    verify(response).setContentType("application/json");
+    verify(response).setCharacterEncoding("UTF-8");
+    verify(writer).write("인증 실패하였습니다.");
+  }
+}

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandlerTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandlerTest.java
@@ -1,0 +1,180 @@
+package com.recipe.jamanchu.auth.oauth2.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.recipe.jamanchu.auth.jwt.JwtUtil;
+import com.recipe.jamanchu.entity.UserEntity;
+import com.recipe.jamanchu.model.type.UserRole;
+import com.recipe.jamanchu.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.RedirectStrategy;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2SuccessHandlerTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private BCryptPasswordEncoder passwordEncoder;
+
+  @Mock
+  private JwtUtil jwtUtil;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private Authentication authentication;
+
+  @Mock
+  private OAuth2User oAuth2User;
+
+  @Mock
+  private RedirectStrategy redirectStrategy;
+
+  @InjectMocks
+  private OAuth2SuccessHandler oAuth2SuccessHandler;
+
+  @Test
+  @DisplayName("OAuth2 로그인 성공: 새로운 사용자")
+  void oAuthLoginNewUser() throws IOException {
+    // given
+    Map<String, Object> kakaoAccount = new HashMap<>();
+    kakaoAccount.put("email", "test@example.com");
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("nickname", "testNickname");
+
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("id", "providerId");
+    attributes.put("kakao_account", kakaoAccount);
+    attributes.put("properties", properties);
+
+    when(authentication.getPrincipal()).thenReturn(oAuth2User);
+    when(oAuth2User.getAttributes()).thenReturn(attributes);
+
+    String providerId = "providerId";
+    String email = "test@example.com";
+    String nickname = "testNickname";
+
+    when(userRepository.findByProviderId(providerId)).thenReturn(Optional.empty());
+
+    String encodedPassword = "encodedPassword";
+    when(passwordEncoder.encode(anyString())).thenReturn(encodedPassword);
+
+    UserEntity user = UserEntity.builder()
+        .userId(1L)
+        .email(email)
+        .password(encodedPassword)
+        .nickname(nickname)
+        .provider("kakao")
+        .providerId(providerId)
+        .role(UserRole.USER)
+        .build();
+    when(userRepository.save(any(UserEntity.class))).thenReturn(user);
+
+    String accessToken = "accessToken";
+    String refreshToken = "refreshToken";
+    when(jwtUtil.createJwt("access", user.getUserId(), user.getRole())).thenReturn(accessToken);
+    when(jwtUtil.createJwt("refresh", user.getUserId(), user.getRole())).thenReturn(refreshToken);
+
+    PrintWriter writer = mock(PrintWriter.class);
+    when(response.getWriter()).thenReturn(writer);
+
+    oAuth2SuccessHandler.setRedirectStrategy(redirectStrategy);
+
+    // when
+    oAuth2SuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    verify(response).addHeader("access", accessToken);
+    verify(response).addCookie(any(Cookie.class));
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+    verify(response).setContentType("application/json");
+    verify(response).setCharacterEncoding("UTF-8");
+    verify(writer).write("로그인 성공");
+    verify(redirectStrategy).sendRedirect(eq(request), eq(response), anyString());
+  }
+
+  @Test
+  @DisplayName("OAuth2 로그인 성공: 기존 사용자")
+  void oAuthLoginExistUser() throws IOException {
+    // given
+    Map<String, Object> kakaoAccount = new HashMap<>();
+    kakaoAccount.put("email", "test@example.com");
+
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("nickname", "testNickname");
+
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("id", "providerId");
+    attributes.put("kakao_account", kakaoAccount);
+    attributes.put("properties", properties);
+
+    when(authentication.getPrincipal()).thenReturn(oAuth2User);
+    when(oAuth2User.getAttributes()).thenReturn(attributes);
+
+    String providerId = "providerId";
+    String email = "test@example.com";
+    String nickname = "testNickname";
+
+    UserEntity user = UserEntity.builder()
+        .userId(1L)
+        .email(email)
+        .password("existingPassword")
+        .nickname(nickname)
+        .provider("kakao")
+        .providerId(providerId)
+        .role(UserRole.USER)
+        .build();
+
+    when(userRepository.findByProviderId(providerId)).thenReturn(Optional.of(user));
+
+    String accessToken = "accessToken";
+    String refreshToken = "refreshToken";
+    when(jwtUtil.createJwt("access", user.getUserId(), user.getRole())).thenReturn(accessToken);
+    when(jwtUtil.createJwt("refresh", user.getUserId(), user.getRole())).thenReturn(refreshToken);
+
+    PrintWriter writer = mock(PrintWriter.class);
+    when(response.getWriter()).thenReturn(writer);
+
+    oAuth2SuccessHandler.setRedirectStrategy(redirectStrategy);
+
+    // when
+    oAuth2SuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    verify(response).addHeader("access", accessToken);
+    verify(response).addCookie(any(Cookie.class));
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+    verify(response).setContentType("application/json");
+    verify(response).setCharacterEncoding("UTF-8");
+    verify(writer).write("로그인 성공");
+    verify(redirectStrategy).sendRedirect(eq(request), eq(response), anyString());
+  }
+}


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
OAuth2 (카카오) 로그인 기능을 구현하였습니다.

 - 의존성 추가
    - implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 - 구현한 내용 요약

   - 구현한 클래스
   
      - CustomOauth2UserService: OAuth2 로그인 시 사용자 정보를 처리하는 서비스 클래스.
        - OAuth2 제공자로부터 받은 사용자 정보를 애플리케이션의 사용자로 매핑.
        
      - OAuth2SuccessHandler: OAuth2 인증 성공 시 처리 로직을 담당하는 핸들러 클래스.
        - 인증 성공 시 JWT 토큰을 생성하고, 발급받은 토큰을 지정한 URI로 전달.  
      - OAuth2FailureHandler: OAuth2 인증 실패 시 처리 로직을 담당하는 핸들러 클래스.
      - KakaoUserDetails: 카카오 OAuth2 인증 정보를 담는 클래스.
        - email, nickname,  providerId를 추출하여 회원 가입이나 로그인 처리 가능.
      
   - 수정한 클래스
      - SecurityConfig: oauth2Login 설정을 추가.
      
         - 사용자 정보 엔드포인트에 대한 설정을 정의.
         - OAuth2 인증이 성공했을 때 실행될 핸들러 지정.
         - OAuth2 인증이 실패했을 때 실행될 핸들러 지정.
      - UserEntity: OAuth2 로그인 사용자 정보를 저장하기 위한 필드 추가.
         - provider, providerId 
   - 패키지 변경
      - JwtFilter, JwtUtil, LoginFilter: auth 패키지에서 auth/jwt 패키지로 이동.
      - LoginFilterTest: auth 패키지에서 auth/jwt 패키지로 이동.
   - 단위 테스트
      - OAuth2SuccessHandlerTest: 인증 성공에 대한 테스트 클래스.
        - oAuthLoginExistUser : 인증 성공
        
      - OAuth2FailureHandlerTest: 인증 실패에 대한 테스트 클래스.
        - oAuthLoginFailed : 인증 실패

## 스크린샷

## 주의사항

Closes #12 
