### PR TITLE
[fix] OAuth2 (카카오) 로그인 기능 수정

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -38,7 +38,7 @@ public class JwtFilter extends OncePerRequestFilter {
       return;
     }
 
-    String accessToken = request.getHeader("access");
+    String accessToken = request.getHeader("access-token");
 
     if (accessToken == null) {
       logger.info("Access token is null");
@@ -60,7 +60,7 @@ public class JwtFilter extends OncePerRequestFilter {
   }
 
   private void setAuthenticationFromToken(HttpServletResponse response, String token) {
-    response.addHeader("access", token);
+    response.addHeader("access-token", token);
 
     Authentication authToken = getAuthToken(token);
     SecurityContextHolder.getContext().setAuthentication(authToken);
@@ -90,7 +90,7 @@ public class JwtFilter extends OncePerRequestFilter {
   // refresh 토큰 반환
   private String getRefreshTokenFromCookies(HttpServletRequest request) {
     return Arrays.stream(request.getCookies())
-        .filter(cookie -> "refresh".equals(cookie.getName()))
+        .filter(cookie -> "refresh-token".equals(cookie.getName()))
         .map(Cookie::getValue)
         .findFirst()
         .orElse(null);
@@ -128,7 +128,9 @@ public class JwtFilter extends OncePerRequestFilter {
   private boolean isExcludedPath(String requestURI) {
     return requestURI.equals("/")
         || requestURI.equals("/login")
-        || requestURI.equals("/api/v1/user/signup");
+        || requestURI.equals("/api/v1/user/signup")
+        || requestURI.equals("/oauth2/authorization/kakao")
+        || requestURI.equals("/login/oauth2/code/kakao");
   }
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/LoginFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/LoginFilter.java
@@ -57,7 +57,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
 
-    response.addHeader("access", access);
+    response.addHeader("access-token", access);
     response.addCookie(createCookie(refresh));
     response.setStatus(HttpServletResponse.SC_OK);
     response.setContentType("application/json");
@@ -66,7 +66,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
   }
 
   private Cookie createCookie(String value) {
-    Cookie cookie = new Cookie("refresh", value);
+    Cookie cookie = new Cookie("refresh-token", value);
     cookie.setMaxAge(24 * 60 * 60);
     cookie.setHttpOnly(true);
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -15,7 +15,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
@@ -50,23 +49,16 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
 
-    response.addHeader("access", access);
+    response.addHeader("access-token", access);
     response.addCookie(createCookie(refresh));
     response.setStatus(HttpServletResponse.SC_OK);
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
     response.getWriter().write("로그인 성공");
-
-    log.info("OAuth 로그인 성공");
-    String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/api/v1/test")
-        .build()
-        .toUriString();
-
-    getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
 
   private Cookie createCookie(String value) {
-    Cookie cookie = new Cookie("refresh", value);
+    Cookie cookie = new Cookie("refresh-token", value);
     cookie.setMaxAge(24 * 60 * 60);
     cookie.setHttpOnly(true);
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -50,7 +50,11 @@ public class SecurityConfig {
         .httpBasic(AbstractHttpConfigurer::disable);
     http
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/", "/api/v1/user/signup", "login").permitAll()
+            .requestMatchers("/",
+                "/api/v1/user/signup",
+                "login",
+                "/oauth2/authorization/kakao",
+                "/login/oauth2/code/kakao").permitAll()
             .anyRequest().authenticated()
         );
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/comments/CommentsDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/comments/CommentsDTO.java
@@ -3,7 +3,7 @@ package com.recipe.jamanchu.model.dto.request.comments;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,7 +15,7 @@ public class CommentsDTO {
   @Min(value = 1, message = "잘못된 레시피 ID 입력입니다.")
   private final Long recipeId;
 
-  @NotEmpty(message = "댓글을 입력해주세요.")
+  @NotNull(message = "댓글을 입력해주세요.")
   @Size(min = 1, max = 300, message = "댓글은 1자 이상 300자 이하로 입력해주세요.")
   private final String comment;
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/comments/CommentsUpdateDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/comments/CommentsUpdateDTO.java
@@ -3,7 +3,7 @@ package com.recipe.jamanchu.model.dto.request.comments;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,7 +15,7 @@ public class CommentsUpdateDTO {
   @Min(value = 1, message = "잘못된 댓글 번호입니다.")
   private final Long commentsId;
 
-  @NotEmpty(message = "댓글 내용을 입력해주세요.")
+  @NotNull(message = "댓글 내용을 입력해주세요.")
   @Size(min = 1, max = 300, message = "댓글 내용은 1자 이상 300자 이하로 입력해주세요.")
   private final String comment;
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/model/dto/request/comments/CommentsDTOTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/model/dto/request/comments/CommentsDTOTest.java
@@ -43,7 +43,7 @@ class CommentsDTOTest {
     assertEquals("댓글은 1자 이상 300자 이하로 입력해주세요.", violations.iterator().next().getMessage());
   }
 
-  @DisplayName("댓글 내용은 null이 아니어야ㄴ한다.")
+  @DisplayName("댓글 내용은 null이 아니어야한다.")
   @Test
   void commentMustNotNull() {
     //given


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
OAuth2 (카카오) 로그인 기능을 수정 하였습니다.

 - 수정한 내용 요약
 
   - 수정한 클래스
   
     - JwtFilter, LoginFilter, OAuth2SuccessHandler : JWT 토큰의 헤더명 변경  
        - access -> access-token 
        - refresh -> refresh-token 
        
     - SecurityConfig : 요청에 대한 권한 부여
        - "/oauth2/authorization/kakao"
        - "/login/oauth2/code/kakao"   
## 스크린샷

## 주의사항

Closes #16 
