### PR TITLE
[fix] OAuth2 (카카오) 로그인 기능 수정

### DIFF
--- a/jamanchu/build.gradle
+++ b/jamanchu/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Swagger - SpringDoc
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 tasks.named('test') {

--- a/jamanchu/build.gradle
+++ b/jamanchu/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+	// jsoup
+	implementation 'org.jsoup:jsoup:1.15.3'
+
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -130,7 +130,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
   private boolean isExcludedPath(String requestURI) {
     return requestURI.equals("/")
-        || requestURI.equals("/login")
+        || requestURI.equals("/api/v1/user/login")
         || requestURI.equals("/api/v1/user/signup");
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -38,13 +38,16 @@ public class JwtFilter extends OncePerRequestFilter {
       return;
     }
 
-    String accessToken = request.getHeader("access-token");
+    String authorizationHeader = request.getHeader("Authorization");
 
-    if (accessToken == null) {
-      logger.info("Access token is null");
+    // Bearer 토큰이 헤더에 있는지 확인
+    if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+      logger.info("Authorization header is missing or doesn't start with Bearer");
       filterChain.doFilter(request, response);
       return;
     }
+
+    String accessToken = authorizationHeader.substring(7);
 
     try {
       // access 토큰이 만료가 되지 않은 경우
@@ -60,7 +63,7 @@ public class JwtFilter extends OncePerRequestFilter {
   }
 
   private void setAuthenticationFromToken(HttpServletResponse response, String token) {
-    response.addHeader("access-token", token);
+    response.addHeader("access-token", "Bearer " + token);
 
     Authentication authToken = getAuthToken(token);
     SecurityContextHolder.getContext().setAuthentication(authToken);
@@ -128,9 +131,7 @@ public class JwtFilter extends OncePerRequestFilter {
   private boolean isExcludedPath(String requestURI) {
     return requestURI.equals("/")
         || requestURI.equals("/login")
-        || requestURI.equals("/api/v1/user/signup")
-        || requestURI.equals("/oauth2/authorization/kakao")
-        || requestURI.equals("/login/oauth2/code/kakao");
+        || requestURI.equals("/api/v1/user/signup");
   }
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -38,7 +38,7 @@ public class JwtFilter extends OncePerRequestFilter {
       return;
     }
 
-    String authorizationHeader = request.getHeader("Authorization");
+    String authorizationHeader = request.getHeader("access-token");
 
     // Bearer 토큰이 헤더에 있는지 확인
     if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
@@ -105,7 +105,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     UserEntity user = UserEntity.builder()
         .userId(userId)
-        .role(UserRole.USER)
+        .role(role)
         .build();
 
     UserDetailsDTO userDetails = new UserDetailsDTO(user);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/LoginFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/LoginFilter.java
@@ -57,7 +57,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
 
-    response.addHeader("access-token", access);
+    response.addHeader("access-token", "Bearer " + access);
     response.addCookie(createCookie(refresh));
     response.setStatus(HttpServletResponse.SC_OK);
     response.setContentType("application/json");

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -30,7 +30,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
       Authentication authentication) throws IOException {
-    SecurityContextHolder.getContext().setAuthentication(authentication);
     OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
     KakaoUserDetails kakaoUserDetails = new KakaoUserDetails(oAuth2User.getAttributes());

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -11,10 +11,12 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
@@ -28,7 +30,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
       Authentication authentication) throws IOException {
-
+    SecurityContextHolder.getContext().setAuthentication(authentication);
     OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
     KakaoUserDetails kakaoUserDetails = new KakaoUserDetails(oAuth2User.getAttributes());
@@ -49,12 +51,17 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
 
-    response.addHeader("access-token", access);
+    response.addHeader("access-token", "Bearer " + access);
     response.addCookie(createCookie(refresh));
-    response.setStatus(HttpServletResponse.SC_OK);
-    response.setContentType("application/json");
-    response.setCharacterEncoding("UTF-8");
-    response.getWriter().write("로그인 성공");
+
+    log.info("OAuth 로그인 성공");
+    String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/api/v1/user/test")
+//        .queryParam("access", access)
+//        .queryParam("refresh", refresh)
+        .build()
+        .toUriString();
+
+    getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
 
   private Cookie createCookie(String value) {

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             //swagger ui 허용
             .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-            .requestMatchers("/v3/api-docs/**", "/scrape-recipes",
+            .requestMatchers("/v3/api-docs/**", "/api/v1/scrape-recipes",
                 "/swagger-ui/**",
                 "/swagger-ui.html",
                 "/swagger-resources/**").permitAll()

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.recipe.jamanchu.auth.oauth2.handler.OAuth2FailureHandler;
 import com.recipe.jamanchu.auth.oauth2.handler.OAuth2SuccessHandler;
 import com.recipe.jamanchu.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -50,6 +51,12 @@ public class SecurityConfig {
         .httpBasic(AbstractHttpConfigurer::disable);
     http
         .authorizeHttpRequests(auth -> auth
+            //swagger ui 허용
+            .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+            .requestMatchers("/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/swagger-ui.html",
+                "/swagger-resources/**").permitAll()
             .requestMatchers("/",
                 "/api/v1/user/signup",
                 "/api/v1/user/login",

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             //swagger ui 허용
             .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-            .requestMatchers("/v3/api-docs/**",
+            .requestMatchers("/v3/api-docs/**", "/scrape-recipes",
                 "/swagger-ui/**",
                 "/swagger-ui.html",
                 "/swagger-resources/**").permitAll()

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SwaggerConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package com.recipe.jamanchu.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+        .components(new Components()
+            .addSecuritySchemes("bearerAuth",
+                new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer")
+                    .bearerFormat("JWT")))
+        .info(new Info()
+            .title("JaManChu API")
+            .version("API v1.0")
+            .description("API documentation"));
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/TenThousandRecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/TenThousandRecipeController.java
@@ -3,10 +3,12 @@ package com.recipe.jamanchu.controller;
 import com.recipe.jamanchu.scraper.ScrapTenThousandRecipe;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1")
 public class TenThousandRecipeController {
 
   private final ScrapTenThousandRecipe recipeScrap;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/TenThousandRecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/TenThousandRecipeController.java
@@ -1,0 +1,20 @@
+package com.recipe.jamanchu.controller;
+
+import com.recipe.jamanchu.scraper.ScrapTenThousandRecipe;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TenThousandRecipeController {
+
+  private final ScrapTenThousandRecipe recipeScrap;
+
+  @GetMapping("/scrape-recipes")
+  public String scrapeRecipes() {
+    recipeScrap.scrap();
+    return "Scraping completed!";
+  }
+
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
@@ -8,10 +8,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequiredArgsConstructor

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
@@ -4,16 +4,21 @@ import com.recipe.jamanchu.model.dto.request.auth.SignupDTO;
 import com.recipe.jamanchu.model.type.ResultCode;
 import com.recipe.jamanchu.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user")
 public class UserController {
 
+  private static final Logger log = LoggerFactory.getLogger(UserController.class);
   private final UserService userService;
 
   @PostMapping("/signup")
@@ -21,4 +26,14 @@ public class UserController {
 
     return ResponseEntity.ok(userService.signup(signupDTO));
   }
+
+//  @GetMapping("/test")
+//  public ResponseEntity<?> test(@RequestParam("access") String access,
+//      @RequestParam("refresh") String refresh) {
+//
+//    log.info("access : {}", access);
+//    log.info("refresh : {}", refresh);
+//
+//    return ResponseEntity.ok().body(access);
+//  }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/TenThousandRecipeEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/TenThousandRecipeEntity.java
@@ -1,0 +1,64 @@
+package com.recipe.jamanchu.entity;
+
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "ten_recipe")
+public class TenThousandRecipeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "cr_id")
+  private Long crawledRecipeId;
+
+  @Column(name = "cr_name")
+  private String name;
+
+  @Column(name = "cr_author")
+  private String authorName;
+
+  @Column(name = "cr_description", columnDefinition = "TEXT")
+  private String description;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "cr_level")
+  private LevelType levelType;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "cr_cook_time")
+  private CookingTimeType cookingTimeType;
+
+  @Column(name = "cr_rating")
+  private Double rating;
+
+  @Column(name = "cr_thumbnail")
+  private String thumbnail;
+
+  @Column(name = "cr_ingredients")
+  private String ingredients;
+
+  @NotNull
+  @Column(name = "cr_mn_content", columnDefinition = "TEXT")
+  private String crManualContent;
+
+  @Column(name = "cr_mn_picture", columnDefinition = "TEXT")
+  private String crManualPicture;
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/TenThousandRecipeEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/TenThousandRecipeEntity.java
@@ -49,6 +49,9 @@ public class TenThousandRecipeEntity {
   @Column(name = "cr_rating")
   private Double rating;
 
+  @Column(name = "cr_review_count")
+  private Integer crReviewCount;
+
   @Column(name = "cr_thumbnail")
   private String thumbnail;
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/crawling/ScrapResult.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/crawling/ScrapResult.java
@@ -1,0 +1,23 @@
+package com.recipe.jamanchu.model.dto.response.crawling;
+
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+public class ScrapResult {
+
+  private String title;
+  private String authorName;
+  private String description;
+  private LevelType levelType;
+  private CookingTimeType cookTime;
+  private String thumbnail;
+  private Double rating;
+  private String ingredients;
+  private String manualContents;
+  private String manualPictures;
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/crawling/ScrapResult.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/crawling/ScrapResult.java
@@ -3,10 +3,9 @@ package com.recipe.jamanchu.model.dto.response.crawling;
 import com.recipe.jamanchu.model.type.CookingTimeType;
 import com.recipe.jamanchu.model.type.LevelType;
 import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class ScrapResult {
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/crawling/ScrapResult.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/crawling/ScrapResult.java
@@ -16,6 +16,7 @@ public class ScrapResult {
   private CookingTimeType cookTime;
   private String thumbnail;
   private Double rating;
+  private Integer reviewCount;
   private String ingredients;
   private String manualContents;
   private String manualPictures;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/CookingTimeType.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/CookingTimeType.java
@@ -6,12 +6,29 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum CookingTimeType {
+  FIVE_MINUTES("5분 이내"),
   TEN_MINUTES("10분 이내"),
   FIFTEEN_MINUTES("15분 이내"),
+  TWENTY_MINUTES("20분 이내"),
   THIRTY_MINUTES("30분 이내"),
-  ONE_HOURS("60분 이내"),
+  ONE_HOUR("60분 이내"),
   TWO_HOURS("60분 이상")
   ;
 
   private final String time;
+
+  public static CookingTimeType fromString(String cookTime) {
+    if (cookTime == null) {
+      return null; // null 값 처리
+    }
+    return switch (cookTime) {
+      case "5분 이내" -> FIVE_MINUTES;
+      case "10분 이내" -> TEN_MINUTES;
+      case "15분 이내" -> FIFTEEN_MINUTES;
+      case "20분 이내" -> TWENTY_MINUTES;
+      case "30분 이내" -> THIRTY_MINUTES;
+      case "60분 이내" -> ONE_HOUR;
+      default -> TWO_HOURS;
+    };
+  }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/LevelType.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/LevelType.java
@@ -11,4 +11,16 @@ public enum LevelType {
   HIGH("고급");
 
   private final String level;
+
+  public static LevelType fromString(String level) {
+    if (level == null) {
+      return null;
+    }
+
+    return switch (level) {
+      case "중급" -> MEDIUM;
+      case "고급" -> HIGH;
+      default -> LOW;
+    };
+  }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
@@ -10,6 +10,7 @@ public enum ResultCode {
 
   SUCCESS_SIGNUP(HttpStatus.CREATED, "회원가입 성공!"),
   SUCCESS_COMMENTS(HttpStatus.CREATED, "댓글 작성 성공!"),
+  SUCCESS_CR_RECIPE(HttpStatus.CREATED, "스크래핑 레시피 저장 성공!"),
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/TenThousandRecipeRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/TenThousandRecipeRepository.java
@@ -1,0 +1,10 @@
+package com.recipe.jamanchu.repository;
+
+import com.recipe.jamanchu.entity.TenThousandRecipeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TenThousandRecipeRepository extends JpaRepository<TenThousandRecipeEntity, Long> {
+
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/scraper/ScrapTenThousandRecipe.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/scraper/ScrapTenThousandRecipe.java
@@ -74,33 +74,28 @@ public class ScrapTenThousandRecipe {
       Document recipeDoc = Jsoup.connect(url).get();
 
       // title 추출
-      Element titleElement = recipeDoc.selectFirst(".view2_summary h3");
-      String title = (titleElement != null) ? titleElement.text() : null;
+      String title = getText(recipeDoc, ".view2_summary h3");
+      if (title == null) return null;
 
       // authorName 추출
-      Element authorElement = recipeDoc.selectFirst(".user_info2_name");
-      String authorName = (authorElement != null) ? authorElement.text() : null;
+      String authorName = getText(recipeDoc, ".user_info2_name");
 
       // description 추출
-      Element descriptionElement = recipeDoc.selectFirst(".view2_summary_in");
-      String description = (descriptionElement != null) ? descriptionElement.text() : null;
+      String description = getText(recipeDoc, ".view2_summary_in");
 
       // level 추출
-      Element levelElement = recipeDoc.selectFirst(".view2_summary_info3");
-      String level = (levelElement != null) ? levelElement.text() : null;
+      String level = getText(recipeDoc, ".view2_summary_info3");
       LevelType levelType = LevelType.fromString(level);
 
       // cookTime 추출
-      Element cookTimeElement = recipeDoc.selectFirst(".view2_summary_info2");
-      String cookTime = (cookTimeElement != null) ? cookTimeElement.text() : null;
+      String cookTime = getText(recipeDoc, ".view2_summary_info2");
       CookingTimeType cookingTimeType = CookingTimeType.fromString(cookTime);
 
       // thumbnail 추출
-      Element thumbnailElement = recipeDoc.selectFirst(".centeredcrop img");
-      String thumbnail = (thumbnailElement != null) ? thumbnailElement.attr("src") : null;
+      String thumbnail = getAttr(recipeDoc, ".centeredcrop img", "src");
 
       // averageRating 계산
-      List<Integer> reviewsRating = scrapeReviews(recipeDoc);
+      List<Integer> reviewsRating = scrapeReviewsRating(recipeDoc);
 
       double averageRating = reviewsRating.stream()
           .mapToInt(Integer::intValue)
@@ -151,7 +146,17 @@ public class ScrapTenThousandRecipe {
     return null;  // 에러 발생 시 null 반환
   }
 
-  public List<Integer> scrapeReviews(Document document) throws IOException {
+  private String getText(Document doc, String cssQuery) {
+    Element element = doc.selectFirst(cssQuery);
+    return (element != null) ? element.text() : null;
+  }
+
+  private String getAttr(Document doc, String cssQuery, String attribute) {
+    Element element = doc.selectFirst(cssQuery);
+    return (element != null) ? element.attr(attribute) : null;
+  }
+
+  private List<Integer> scrapeReviewsRating(Document document) throws IOException {
     List<Integer> ratings = new ArrayList<>();
     Elements reviewElements = document.select(".media.reply_list");
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/scraper/ScrapTenThousandRecipe.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/scraper/ScrapTenThousandRecipe.java
@@ -48,7 +48,7 @@ public class ScrapTenThousandRecipe {
             recipeBatch.add(result);
           }
 
-          if (recipeBatch.size() >= 40) {  // 레시피 40개씩 저장
+          if (recipeBatch.size() >= 1000) {  // 레시피 1000개씩 저장
             scrapRecipeService.saveCrawlRecipe(recipeBatch);
             recipeBatch.clear();
           }
@@ -96,7 +96,7 @@ public class ScrapTenThousandRecipe {
 
       // averageRating 계산
       List<Integer> reviewsRating = scrapeReviewsRating(recipeDoc);
-
+      int reviewCount = reviewsRating.size();
       double averageRating = reviewsRating.stream()
           .mapToInt(Integer::intValue)
           .average()
@@ -136,7 +136,7 @@ public class ScrapTenThousandRecipe {
       }
 
       // ScrapResult 객체 반환
-      return new ScrapResult(title, authorName, description, levelType, cookingTimeType, thumbnail, averageRating, ingredients.toString(),
+      return new ScrapResult(title, authorName, description, levelType, cookingTimeType, thumbnail, averageRating, reviewCount, ingredients.toString(),
           manualContents.toString(), manualPictures.toString());
 
     } catch (IOException e) {

--- a/jamanchu/src/main/java/com/recipe/jamanchu/scraper/ScrapTenThousandRecipe.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/scraper/ScrapTenThousandRecipe.java
@@ -1,0 +1,167 @@
+package com.recipe.jamanchu.scraper;
+
+import com.recipe.jamanchu.model.dto.response.crawling.ScrapResult;
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
+import com.recipe.jamanchu.service.ScrapTenThousandRecipeService;
+import lombok.AllArgsConstructor;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class ScrapTenThousandRecipe {
+
+  private static final String url = "https://www.10000recipe.com/recipe/list.html";
+  private final ScrapTenThousandRecipeService scrapRecipeService;
+
+  public void scrap() {
+    int pageNumber = 1; // 시작 페이지
+    List<ScrapResult> recipeBatch = new ArrayList<>();
+
+    while (true) {
+      try {
+        // 현재 페이지 URL 구성
+        String pageUrl = url + "?page=" + pageNumber;
+        // 웹페이지를 Jsoup으로 파싱
+        Document document = Jsoup.connect(pageUrl).get();
+
+        // 레시피 목록에서 레시피 링크 가져오기
+        Elements recipeLinks = document.select(".common_sp_list_ul .common_sp_link");
+
+        // 만약 레시피 링크가 없으면 반복 종료
+        if (recipeLinks.isEmpty()) {
+          break;
+        }
+
+        // 각 레시피 상세 페이지 방문
+        for (Element link : recipeLinks) {
+          String recipeUrl = "https://www.10000recipe.com" + link.attr("href");
+          ScrapResult result = scrapeRecipeDetails(recipeUrl);
+          if (result != null) {
+            recipeBatch.add(result);
+          }
+
+          if (recipeBatch.size() >= 40) {  // 레시피 40개씩 저장
+            scrapRecipeService.saveCrawlRecipe(recipeBatch);
+            recipeBatch.clear();
+          }
+        }
+
+        pageNumber++; // 다음 페이지로 이동
+        System.out.println("===================="+pageNumber+"==================");
+      } catch (IOException e) {
+        e.printStackTrace();
+        break; // 오류 발생 시 반복 종료
+      }
+    }
+
+    // 남은 레시피 저장 (40개 미만일 경우)
+    if (!recipeBatch.isEmpty()) {
+      scrapRecipeService.saveCrawlRecipe(recipeBatch);
+    }
+  }
+
+  private ScrapResult scrapeRecipeDetails(String url) {
+    try {
+      // 레시피 상세 페이지 파싱
+      Document recipeDoc = Jsoup.connect(url).get();
+
+      // title 추출
+      Element titleElement = recipeDoc.selectFirst(".view2_summary h3");
+      String title = (titleElement != null) ? titleElement.text() : null;
+
+      // authorName 추출
+      Element authorElement = recipeDoc.selectFirst(".user_info2_name");
+      String authorName = (authorElement != null) ? authorElement.text() : null;
+
+      // description 추출
+      Element descriptionElement = recipeDoc.selectFirst(".view2_summary_in");
+      String description = (descriptionElement != null) ? descriptionElement.text() : null;
+
+      // level 추출
+      Element levelElement = recipeDoc.selectFirst(".view2_summary_info3");
+      String level = (levelElement != null) ? levelElement.text() : null;
+      LevelType levelType = LevelType.fromString(level);
+
+      // cookTime 추출
+      Element cookTimeElement = recipeDoc.selectFirst(".view2_summary_info2");
+      String cookTime = (cookTimeElement != null) ? cookTimeElement.text() : null;
+      CookingTimeType cookingTimeType = CookingTimeType.fromString(cookTime);
+
+      // thumbnail 추출
+      Element thumbnailElement = recipeDoc.selectFirst(".centeredcrop img");
+      String thumbnail = (thumbnailElement != null) ? thumbnailElement.attr("src") : null;
+
+      // averageRating 계산
+      List<Integer> reviewsRating = scrapeReviews(recipeDoc);
+
+      double averageRating = reviewsRating.stream()
+          .mapToInt(Integer::intValue)
+          .average()
+          .orElse(0.0);
+
+      averageRating = Math.round(averageRating * 100.0) / 100.0;
+
+      // ingredient 추출
+      Element ingredientElement = recipeDoc.selectFirst("#divConfirmedMaterialArea");
+      StringBuilder ingredients = new StringBuilder();
+      if (ingredientElement != null) {
+        Elements ingredientLists = ingredientElement.select("ul");
+        for (Element ingredientList : ingredientLists) {
+          // 각 재료 항목 추출
+          Elements items = ingredientList.select("li");
+          for (Element item : items) {
+            String ingredientName = item.selectFirst(".ingre_list_name").text();
+            String ingredientAmount = item.selectFirst(".ingre_list_ea").text();
+            ingredients.append(ingredientName).append(" ").append(ingredientAmount).append(",");
+          }
+        }
+      }
+
+      // 조리 순서 및 이미지
+      Elements stepsElements = recipeDoc.select(".view_step_cont");
+      Elements stepImagesElements = recipeDoc.select(".view_step_cont img");
+
+      StringBuilder manualContents = new StringBuilder();
+      StringBuilder manualPictures = new StringBuilder();
+
+      for (Element step : stepsElements) {
+        manualContents.append(step.text()).append("$%^");
+      }
+
+      for (Element image : stepImagesElements) {
+        manualPictures.append(image.attr("src")).append(",");
+      }
+
+      // ScrapResult 객체 반환
+      return new ScrapResult(title, authorName, description, levelType, cookingTimeType, thumbnail, averageRating, ingredients.toString(),
+          manualContents.toString(), manualPictures.toString());
+
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    return null;  // 에러 발생 시 null 반환
+  }
+
+  public List<Integer> scrapeReviews(Document document) throws IOException {
+    List<Integer> ratings = new ArrayList<>();
+    Elements reviewElements = document.select(".media.reply_list");
+
+    for (Element reviewElement : reviewElements) {
+      // 평점 추출 (이미지의 개수로 평점 계산)
+      int starRating = reviewElement.select(".reply_list_star img[src='https://recipe1.ezmember.co.kr/img/mobile/icon_star2_on.png']").size();
+      ratings.add(starRating);
+    }
+
+    return ratings; // 평점 리스트 반환
+  }
+
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/ScrapTenThousandRecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/ScrapTenThousandRecipeService.java
@@ -1,0 +1,9 @@
+package com.recipe.jamanchu.service;
+
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import com.recipe.jamanchu.model.dto.response.crawling.ScrapResult;
+import java.util.List;
+
+public interface ScrapTenThousandRecipeService {
+  public ResultResponse saveCrawlRecipe(List<ScrapResult> scrapResult);
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/ScrapTenThousandRecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/ScrapTenThousandRecipeService.java
@@ -5,5 +5,5 @@ import com.recipe.jamanchu.model.dto.response.crawling.ScrapResult;
 import java.util.List;
 
 public interface ScrapTenThousandRecipeService {
-  public ResultResponse saveCrawlRecipe(List<ScrapResult> scrapResult);
+  ResultResponse saveCrawlRecipe(List<ScrapResult> scrapResult);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImpl.java
@@ -1,0 +1,41 @@
+package com.recipe.jamanchu.service.impl;
+
+import com.recipe.jamanchu.entity.TenThousandRecipeEntity;
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import com.recipe.jamanchu.model.dto.response.crawling.ScrapResult;
+import com.recipe.jamanchu.model.type.ResultCode;
+import com.recipe.jamanchu.repository.TenThousandRecipeRepository;
+import com.recipe.jamanchu.service.ScrapTenThousandRecipeService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapTenThousandRecipeServiceImpl implements ScrapTenThousandRecipeService {
+
+  private final TenThousandRecipeRepository crawledRecipeRepository;
+
+  @Override
+  @Transactional
+  public ResultResponse saveCrawlRecipe(List<ScrapResult> scrapResults) {
+    crawledRecipeRepository.saveAll(scrapResults.stream()
+        .map(scrapResult -> TenThousandRecipeEntity.builder()
+            .name(scrapResult.getTitle())
+            .authorName(scrapResult.getAuthorName())
+            .description(scrapResult.getDescription())
+            .levelType(scrapResult.getLevelType())
+            .cookingTimeType(scrapResult.getCookTime())
+            .ingredients(scrapResult.getIngredients())
+            .thumbnail(scrapResult.getThumbnail())
+            .rating(scrapResult.getRating())
+            .crManualContent(scrapResult.getManualContents())
+            .crManualPicture(scrapResult.getManualPictures())
+            .build())
+        .collect(Collectors.toList()));
+
+    return ResultResponse.of(ResultCode.SUCCESS_CR_RECIPE);
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImpl.java
@@ -31,6 +31,7 @@ public class ScrapTenThousandRecipeServiceImpl implements ScrapTenThousandRecipe
             .ingredients(scrapResult.getIngredients())
             .thumbnail(scrapResult.getThumbnail())
             .rating(scrapResult.getRating())
+            .crReviewCount(scrapResult.getReviewCount())
             .crManualContent(scrapResult.getManualContents())
             .crManualPicture(scrapResult.getManualPictures())
             .build())

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/jwt/LoginFilterTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/jwt/LoginFilterTest.java
@@ -87,7 +87,7 @@ class LoginFilterTest {
     loginFilter.successfulAuthentication(request, response, chain, authentication);
 
     // then
-    verify(response).addHeader("access", accessToken);
+    verify(response).addHeader("access-token", "Bearer " + accessToken);
     verify(response).addCookie(any(Cookie.class));
     verify(response).setStatus(HttpServletResponse.SC_OK);
     verify(response).setContentType("application/json");

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandlerTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandlerTest.java
@@ -3,7 +3,6 @@ package com.recipe.jamanchu.auth.oauth2.handler;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,7 +14,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandlerTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandlerTest.java
@@ -2,6 +2,7 @@ package com.recipe.jamanchu.auth.oauth2.handler;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.RedirectStrategy;
 
 @ExtendWith(MockitoExtension.class)
 class OAuth2SuccessHandlerTest {
@@ -51,6 +53,9 @@ class OAuth2SuccessHandlerTest {
 
   @Mock
   private OAuth2User oAuth2User;
+
+  @Mock
+  private RedirectStrategy redirectStrategy;
 
   @InjectMocks
   private OAuth2SuccessHandler oAuth2SuccessHandler;
@@ -98,19 +103,15 @@ class OAuth2SuccessHandlerTest {
     when(jwtUtil.createJwt("access", user.getUserId(), user.getRole())).thenReturn(accessToken);
     when(jwtUtil.createJwt("refresh", user.getUserId(), user.getRole())).thenReturn(refreshToken);
 
-    PrintWriter writer = mock(PrintWriter.class);
-    when(response.getWriter()).thenReturn(writer);
+    oAuth2SuccessHandler.setRedirectStrategy(redirectStrategy);
 
     // when
     oAuth2SuccessHandler.onAuthenticationSuccess(request, response, authentication);
 
     // then
-    verify(response).addHeader("access-token", accessToken);
+    verify(response).addHeader("access-token", "Bearer " + accessToken);
     verify(response).addCookie(any(Cookie.class));
-    verify(response).setStatus(HttpServletResponse.SC_OK);
-    verify(response).setContentType("application/json");
-    verify(response).setCharacterEncoding("UTF-8");
-    verify(writer).write("로그인 성공");
+    verify(redirectStrategy).sendRedirect(eq(request), eq(response), anyString());
   }
 
   @Test
@@ -152,18 +153,14 @@ class OAuth2SuccessHandlerTest {
     when(jwtUtil.createJwt("access", user.getUserId(), user.getRole())).thenReturn(accessToken);
     when(jwtUtil.createJwt("refresh", user.getUserId(), user.getRole())).thenReturn(refreshToken);
 
-    PrintWriter writer = mock(PrintWriter.class);
-    when(response.getWriter()).thenReturn(writer);
+    oAuth2SuccessHandler.setRedirectStrategy(redirectStrategy);
 
     // when
     oAuth2SuccessHandler.onAuthenticationSuccess(request, response, authentication);
 
     // then
-    verify(response).addHeader("access-token", accessToken);
+    verify(response).addHeader("access-token", "Bearer " + accessToken);
     verify(response).addCookie(any(Cookie.class));
-    verify(response).setStatus(HttpServletResponse.SC_OK);
-    verify(response).setContentType("application/json");
-    verify(response).setCharacterEncoding("UTF-8");
-    verify(writer).write("로그인 성공");
+    verify(redirectStrategy).sendRedirect(eq(request), eq(response), anyString());
   }
 }

--- a/jamanchu/src/test/java/com/recipe/jamanchu/entity/TenThousandRecipeEntityTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/entity/TenThousandRecipeEntityTest.java
@@ -1,0 +1,59 @@
+package com.recipe.jamanchu.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
+import com.recipe.jamanchu.repository.TenThousandRecipeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TenThousandRecipeEntityTest {
+
+  @Mock
+  private TenThousandRecipeRepository tenThousandRecipeRepository;
+
+  @Test
+  @DisplayName("TenThousandRecipe Entity Builder Test")
+  void builder() {
+
+    // given
+    TenThousandRecipeEntity recipeEntity = TenThousandRecipeEntity.builder()
+        .crawledRecipeId(1L)
+        .name("TenThousandRecipeName")
+        .authorName("authorName")
+        .description("description")
+        .levelType(LevelType.LOW)
+        .cookingTimeType(CookingTimeType.TEN_MINUTES)
+        .rating(4.50)
+        .thumbnail("thumbnail")
+        .ingredients("ingredients")
+        .crManualContent("contents")
+        .crManualPicture("pictures")
+        .build();
+
+    // when
+    when(tenThousandRecipeRepository.save(recipeEntity)).thenReturn(recipeEntity);
+
+    // act
+    TenThousandRecipeEntity savedRecipe = tenThousandRecipeRepository.save(recipeEntity);
+
+    // then
+    assertEquals(1, savedRecipe.getCrawledRecipeId());
+    assertEquals("TenThousandRecipeName", savedRecipe.getName());
+    assertEquals("authorName", savedRecipe.getAuthorName());
+    assertEquals("description", savedRecipe.getDescription());
+    assertEquals(LevelType.LOW, savedRecipe.getLevelType());
+    assertEquals(CookingTimeType.TEN_MINUTES, savedRecipe.getCookingTimeType());
+    assertEquals(4.50, savedRecipe.getRating());
+    assertEquals("thumbnail", savedRecipe.getThumbnail());
+    assertEquals("ingredients", savedRecipe.getIngredients());
+    assertEquals("contents", savedRecipe.getCrManualContent());
+    assertEquals("pictures", savedRecipe.getCrManualPicture());
+  }
+}

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImplTest.java
@@ -1,0 +1,58 @@
+package com.recipe.jamanchu.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import com.recipe.jamanchu.model.dto.response.crawling.ScrapResult;
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
+import com.recipe.jamanchu.repository.TenThousandRecipeRepository;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ScrapTenThousandRecipeServiceImplTest {
+
+  @Mock
+  private TenThousandRecipeRepository tenThousandRecipeRepository;
+
+  @InjectMocks
+  private ScrapTenThousandRecipeServiceImpl scrapTenThousandRecipeService;
+
+  @Test
+  void saveCrawlRecipe_Success() {
+
+    // given
+    ScrapResult scrapResult1 = new ScrapResult(
+        "Recipe 1", "Author 1", "Delicious recipe 1",
+        LevelType.LOW, CookingTimeType.FIFTEEN_MINUTES, "recipe1.jpg",
+        4.5, "Eggs, Butter", "Step 1, Step 2",
+        "step1.jpg, step2.jpg");
+
+    ScrapResult scrapResult2 = new ScrapResult(
+        "Recipe 2", "Author 2", "Delicious recipe 2",
+        LevelType.MEDIUM, CookingTimeType.THIRTY_MINUTES, "recipe2.jpg",
+        4.7, "Chicken, Garlic", "Step 1, Step 2",
+        "step1.jpg, step2.jpg");
+
+    List<ScrapResult> scrapResults = Arrays.asList(scrapResult1, scrapResult2);
+
+    // when
+    ResultResponse resultResponse = scrapTenThousandRecipeService.saveCrawlRecipe(scrapResults);
+
+    // Then
+    assertEquals("스크래핑 레시피 저장 성공!", resultResponse.getMessage());
+
+    // verify
+    verify(tenThousandRecipeRepository, times(1)).saveAll(anyList());
+  }
+
+}

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImplTest.java
@@ -12,6 +12,7 @@ import com.recipe.jamanchu.model.type.LevelType;
 import com.recipe.jamanchu.repository.TenThousandRecipeRepository;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,19 +29,20 @@ class ScrapTenThousandRecipeServiceImplTest {
   private ScrapTenThousandRecipeServiceImpl scrapTenThousandRecipeService;
 
   @Test
+  @DisplayName("스크래핑 데이터 저장 성공")
   void saveCrawlRecipe_Success() {
 
     // given
     ScrapResult scrapResult1 = new ScrapResult(
         "Recipe 1", "Author 1", "Delicious recipe 1",
         LevelType.LOW, CookingTimeType.FIFTEEN_MINUTES, "recipe1.jpg",
-        4.5, "Eggs, Butter", "Step 1, Step 2",
+        4.5, 14, "Eggs, Butter", "Step 1, Step 2",
         "step1.jpg, step2.jpg");
 
     ScrapResult scrapResult2 = new ScrapResult(
         "Recipe 2", "Author 2", "Delicious recipe 2",
         LevelType.MEDIUM, CookingTimeType.THIRTY_MINUTES, "recipe2.jpg",
-        4.7, "Chicken, Garlic", "Step 1, Step 2",
+        4.7, 5,"Chicken, Garlic", "Step 1, Step 2",
         "step1.jpg, step2.jpg");
 
     List<ScrapResult> scrapResults = Arrays.asList(scrapResult1, scrapResult2);


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? 예. `[feat] PR을 등록한다. `
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
OAuth2 (카카오) 로그인 기능을 수정하였습니다.

 - 수정한 내용 요약

   - 수정한 클래스
   
      - OAuth2SuccessHandler : Redirect 경로 추가
        - 인증 성공시 "http://localhost:8080/api/v1/user/test" 경로로 Redirect.
       
      - LoginFilter, JwtFilter : JWT 토큰값에 "Bearer " 문자열 추가
      - SecurityConfig : 로그인 시 요청할 경로 수정
         - customLoginFilter를 활용하여 "/api/v1/user/login" 경로로 요청을 해야 로그인 가능.
      - UserController : OAuth2SuccessHandler에서 Redirect 요청을 받아줄 메서드 구현. 
      - LoginFilterTest : 수정한 LoginFilter 클래스에 맞게 테스트 코드 수정.
      - OAuth2SuccessHandlerTest : 수정한 OAuth2SuccessHandler 클래스에 맞게 테스트 코드 수정.

## 스크린샷

## 주의사항

닫기 #24 
