### PR TITLE
[fix] OAuth2 로그인 성공시 리다이렉트 로직 수정 및 로그 추가

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -34,6 +34,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     // 인증이 필요 없는 경로
     if (isExcludedPath(requestURI)) {
+      logger.info("requestURI -> {}", requestURI);
       filterChain.doFilter(request, response);
       return;
     }
@@ -131,7 +132,8 @@ public class JwtFilter extends OncePerRequestFilter {
   private boolean isExcludedPath(String requestURI) {
     return requestURI.equals("/")
         || requestURI.equals("/api/v1/user/login")
-        || requestURI.equals("/api/v1/user/signup");
+        || requestURI.equals("/api/v1/user/signup")
+        || requestURI.equals("/api/v1/user/test");
   }
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/CustomOauth2UserService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/CustomOauth2UserService.java
@@ -1,6 +1,7 @@
 package com.recipe.jamanchu.auth.oauth2;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
@@ -8,6 +9,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
@@ -15,6 +17,7 @@ public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequ
   @Override
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
+    log.info("loadUser -> userRequest : {}", userRequest);
     return new DefaultOAuth2UserService().loadUser(userRequest);
   }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -55,11 +55,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     log.info("OAuth 로그인 성공");
     String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/api/v1/user/test")
-//        .queryParam("access", access)
-//        .queryParam("refresh", refresh)
+        .queryParam("access", access)
+        .queryParam("refresh", refresh)
         .build()
         .toUriString();
 
+    log.info("redirect -> http://localhost:8080/api/v1/user/test");
     getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
@@ -8,8 +8,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequiredArgsConstructor
@@ -25,13 +27,15 @@ public class UserController {
     return ResponseEntity.ok(userService.signup(signupDTO));
   }
 
-//  @GetMapping("/test")
-//  public ResponseEntity<?> test(@RequestParam("access") String access,
-//      @RequestParam("refresh") String refresh) {
-//
-//    log.info("access : {}", access);
-//    log.info("refresh : {}", refresh);
-//
-//    return ResponseEntity.ok().body(access);
-//  }
+  @GetMapping("/test")
+  public ResponseEntity<?> test(@RequestParam("access") String access,
+      @RequestParam("refresh") String refresh) {
+
+    log.info("method -> test");
+
+    log.info("access : {}", access);
+    log.info("refresh : {}", refresh);
+
+    return ResponseEntity.ok().body("로그인 성공");
+  }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
리다이렉트 로직 주석 해제 및 로그를 추가 하였습니다.

- 수정한 내용 요약

   - 수정한 클래스 
   
     - OAuth2SuccessHandler : 주석제거
    
       - .queryParam("access", access)
       - .queryParam("refresh", refresh)
     - JwtFilter : 인증이 필요없는 경로 제거
        - "/api/v1/user/signup"
        - "/api/v1/user/test"
     - CustomOauth2UserService : 정보를 확인 하기 위해 로그 추가
        - loadUser 메서드가 호출이 될때 OAuth2UserRequest 값 로그 출력 
     - UserController : test 메서드 주석제거
     

## 스크린샷

## 주의사항

Closes #30 
