### PR TITLE
[feat] Jacoco Test Coverage 도입

### DIFF
--- a/jamanchu/build.gradle
+++ b/jamanchu/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.4'
 	id 'io.spring.dependency-management' version '1.1.6'
+	id 'jacoco'
 }
 
 group = 'com.recipe'
@@ -66,4 +67,30 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jacocoTestReport {
+	reports {
+		xml.required = true
+		html.required = true
+		csv.required = false
+	}
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			element = 'CLASS'
+
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.90
+			}
+		}
+	}
+}
+
+tasks.test {
+	finalizedBy jacocoTestReport // 테스트가 끝난 후에 JaCoCo 리포트 생성
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용

## 스크린샷


![image](https://github.com/user-attachments/assets/d7c09005-709e-4cf6-aabf-2b4051eb6517)
./build/reports/jacoco/test/html/index.html 을 확인하면 테스트코드에 대한 커버리지가 보이는 것을 볼 수 있습니다.

![image](https://github.com/user-attachments/assets/23fc1ef2-da33-464d-aed3-71b2322379c1)
/server/impl 패키지에 대한 테스트 커버리지가 100퍼센트가 아닌 걸 볼 수 있는데,

![image](https://github.com/user-attachments/assets/b8a1e735-7904-45df-92d3-68434ab2aeab)
updateComment하는 메서드에 대한 일부 테스트가 존재하지 않는다는 것을 알 수 있습니다.

![image](https://github.com/user-attachments/assets/9e2308b7-79db-4317-8d00-2006d06c74eb)
100%가 아닌 테스트코드를 확인해보면 특정 예외를 던져하는 부분이 테스트되지 않아서 90%로 나오는 것을 확인할 수 있습니다.

![image](https://github.com/user-attachments/assets/2d731a06-8cf6-40c5-8fbd-8868f6f75f17)
추가적인 테스트 코드를 작성하고 성공하는 것을 확인했습니다.

다시 Jacoco를 실행해보면, 

![image](https://github.com/user-attachments/assets/8ea503df-5fef-4b1c-b751-e252af875787)
updateComment 부분이 100%가 된 것을 확인할 수 있습니다.

## 주의사항

Closes #40 