### PR TITLE
[feat] 레시피에 댓글 작성 시 레시피 작성자에게 알림 기능 구현

### DIFF
--- a/jamanchu/build.gradle
+++ b/jamanchu/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 
 	// Swagger - SpringDoc
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+	// Notify
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,7 +134,8 @@ public class JwtFilter extends OncePerRequestFilter {
     return requestURI.equals("/")
         || requestURI.equals("/api/v1/users/login")
         || requestURI.equals("/api/v1/users/signup")
-        || requestURI.equals("/api/v1/users/test");
+        || requestURI.equals("/api/v1/users/test")
+        || Pattern.matches("/api/v1/notify/.*",requestURI);
   }
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtUtil.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtUtil.java
@@ -23,6 +23,9 @@ public class JwtUtil {
   }
 
   public Long getUserId(String token) {
+    if(token.startsWith("Bearer ")) {
+      token = token.substring(7);
+    }
     return Jwts.parser().verifyWith(secretKey).build()
         .parseSignedClaims(token)
         .getPayload()

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -60,7 +60,8 @@ public class SecurityConfig {
             .requestMatchers("/",
                 "/api/v1/users/signup",
                 "/api/v1/users/login",
-                "/api/v1/users/test").permitAll()
+                "/api/v1/users/test",
+                "/api/v1/notify/**").permitAll()
             .anyRequest().authenticated());
 
     http

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/notify/Notify.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/notify/Notify.java
@@ -1,0 +1,22 @@
+package com.recipe.jamanchu.model.dto.response.notify;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Notify {
+
+  private final String recipeName;
+
+  private final String message;
+
+  private final Double rating;
+
+  private final String commentUser;
+
+  public static Notify of(String recipeName, String message, Double rating, String commentUser) {
+    return new Notify(recipeName, message, rating, commentUser);
+  }
+
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/notify/NotifyController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/notify/NotifyController.java
@@ -2,7 +2,6 @@ package com.recipe.jamanchu.notify;
 
 import com.recipe.jamanchu.model.dto.response.notify.Notify;
 import com.recipe.jamanchu.service.impl.NotifyServiceImpl;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/notify/NotifyController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/notify/NotifyController.java
@@ -1,0 +1,31 @@
+package com.recipe.jamanchu.notify;
+
+import com.recipe.jamanchu.model.dto.response.notify.Notify;
+import com.recipe.jamanchu.service.impl.NotifyServiceImpl;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@RestController
+public class NotifyController {
+
+  private final NotifyServiceImpl notifyService;
+
+  @GetMapping(value = "/notify/{recipeId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public Flux<Notify> getNotifications(HttpServletRequest request,
+      @PathVariable("recipeId") Long recipeId) {
+    log.info("getNotifications recipeId: {}", recipeId);
+    return Flux.create(sink -> {
+      notifyService.subscribe(recipeId, sink);
+    });
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/notify/NotifyController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/notify/NotifyController.java
@@ -21,11 +21,7 @@ public class NotifyController {
   private final NotifyServiceImpl notifyService;
 
   @GetMapping(value = "/notify/{recipeId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public Flux<Notify> getNotifications(HttpServletRequest request,
-      @PathVariable("recipeId") Long recipeId) {
-    log.info("getNotifications recipeId: {}", recipeId);
-    return Flux.create(sink -> {
-      notifyService.subscribe(recipeId, sink);
-    });
+  public Flux<Notify> getNotifications(@PathVariable("recipeId") Long recipeId) {
+    return Flux.create(sink -> notifyService.subscribe(recipeId, sink));
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/notify/SubmissionPublisherBean.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/notify/SubmissionPublisherBean.java
@@ -1,0 +1,18 @@
+package com.recipe.jamanchu.notify;
+
+import com.recipe.jamanchu.model.dto.response.notify.Notify;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.FluxSink;
+
+@Component
+public class SubmissionPublisherBean {
+
+  @Bean
+  public Map<Long,FluxSink<Notify>> submissionPublisher(){
+    return new ConcurrentHashMap<>();
+  }
+
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/NotifyService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/NotifyService.java
@@ -1,0 +1,11 @@
+package com.recipe.jamanchu.service;
+
+import com.recipe.jamanchu.model.dto.response.notify.Notify;
+import reactor.core.publisher.FluxSink;
+
+public interface NotifyService {
+
+  void subscribe(Long recipeId, FluxSink<Notify> sink);
+
+  void notifyUser(Long userId, Notify notify);
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/CommentsServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/CommentsServiceImpl.java
@@ -1,5 +1,7 @@
 package com.recipe.jamanchu.service.impl;
 
+import static com.recipe.jamanchu.model.type.RecipeProvider.SCRAP;
+
 import com.recipe.jamanchu.auth.jwt.JwtUtil;
 import com.recipe.jamanchu.component.UserAccessHandler;
 import com.recipe.jamanchu.entity.CommentEntity;
@@ -64,7 +66,7 @@ public class CommentsServiceImpl implements CommentsService {
 
     commentRepository.save(userComment);
 
-    if(!recipe.getUser().getNickname().equals(RecipeProvider.SCRAP.getProvider())){
+    if(recipe.getProvider() != SCRAP){
       Notify notify = Notify.of(recipe.getName(),commentsDTO.getComment(),commentsDTO.getRating(), user.getNickname());
       notifyService.notifyUser(recipe.getUser().getUserId(), notify);
     }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/CommentsServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/CommentsServiceImpl.java
@@ -13,6 +13,8 @@ import com.recipe.jamanchu.model.dto.request.comments.CommentsUpdateDTO;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.model.dto.response.comments.Comment;
 import com.recipe.jamanchu.model.dto.response.comments.Comments;
+import com.recipe.jamanchu.model.dto.response.notify.Notify;
+import com.recipe.jamanchu.model.type.RecipeProvider;
 import com.recipe.jamanchu.model.type.ResultCode;
 import com.recipe.jamanchu.repository.CommentRepository;
 import com.recipe.jamanchu.repository.RecipeRepository;
@@ -32,6 +34,8 @@ public class CommentsServiceImpl implements CommentsService {
   private final CommentRepository commentRepository;
   private final RecipeRepository recipeRepository;
   private final UserAccessHandler userAccessHandler;
+
+  private final NotifyServiceImpl notifyService;
 
   private final JwtUtil jwtUtil;
 
@@ -59,6 +63,11 @@ public class CommentsServiceImpl implements CommentsService {
         .build();
 
     commentRepository.save(userComment);
+
+    if(!recipe.getUser().getNickname().equals(RecipeProvider.SCRAP.getProvider())){
+      Notify notify = Notify.of(recipe.getName(),commentsDTO.getComment(),commentsDTO.getRating(), user.getNickname());
+      notifyService.notifyUser(recipe.getUser().getUserId(), notify);
+    }
 
     return ResultResponse.of(ResultCode.SUCCESS_COMMENTS);
   }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/NotifyServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/NotifyServiceImpl.java
@@ -1,0 +1,29 @@
+package com.recipe.jamanchu.service.impl;
+
+import com.recipe.jamanchu.model.dto.response.notify.Notify;
+import com.recipe.jamanchu.service.NotifyService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.FluxSink;
+
+@RequiredArgsConstructor
+@Service
+public class NotifyServiceImpl implements NotifyService {
+
+  private final Map<Long, FluxSink<Notify>> subscribers;
+
+  @Override
+  public void subscribe(Long recipeId, FluxSink<Notify> sink) {
+    subscribers.put(recipeId, sink);
+    sink.onCancel(() -> subscribers.remove(recipeId));
+  }
+
+  @Override
+  public void notifyUser(Long userId, Notify notify) {
+    FluxSink<Notify> sink = subscribers.get(userId);
+    if (sink != null) {
+      sink.next(notify);
+    }
+  }
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
WebFlux를 통해서 SSE를 구현했습니다.

Flux를 통해 Notify를 TEXT_EVENT_STREAM_VALUE 형식으로 반환하여, 레시피 작성자에게 댓글에 작성된 내용과 레시피의 이름을 전달하도록 설계했습니다.

댓글 작성 시, 레시피의 이름과, 작성자의 이름, 댓글 내용, 평가 점수를 Notify 객체에 담아서 클라이언트 단으로 반환하게 됩니다.

추후 레시피 작성 API 시 recipeId를 반환해서 레시피 id를 통해 구독을 진행하고, 이후 댓글 작성 시 알림을 정상적으로 전달 할 수 있습니다.

단일 controller에서 테스트가 힘들어, 포스트 맨과 웹으로 테스트를 진행했습니다.

## 스크린샷
![image](https://github.com/user-attachments/assets/075810dd-032b-4ab7-8a9b-8b63e4a65548)


## 주의사항

Closes #43 
