### PR TITLE
[feat] 회원 탈퇴 기능 구현

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/LoginFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/LoginFilter.java
@@ -84,14 +84,11 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     UserEntity user = userRepository.findByEmail(request.getParameter("email"))
         .orElseGet(() -> null);
 
-    String enPassword = passwordEncoder.encode(request.getParameter("password"));
 
     if (user == null) {
-      response.getWriter().write("이미 존재하는 아이디 입니다.");
-    } else if (!enPassword.equals(user.getPassword())) {
+      response.getWriter().write("해당 사용자를 찾을 수 없습니다.");
+    } else if (!passwordEncoder.matches(request.getParameter("password"), user.getPassword())) {
       response.getWriter().write("비밀번호를 다시 입력해주세요");
     }
   }
 }
-
-

--- a/jamanchu/src/main/java/com/recipe/jamanchu/component/UserAccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/component/UserAccessHandler.java
@@ -4,6 +4,7 @@ import com.recipe.jamanchu.auth.oauth2.KakaoUserDetails;
 import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedEmailException;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedNicknameException;
+import com.recipe.jamanchu.exceptions.exception.PasswordMismatchException;
 import com.recipe.jamanchu.exceptions.exception.SocialAccountException;
 import com.recipe.jamanchu.exceptions.exception.UserNotFoundException;
 import com.recipe.jamanchu.model.type.UserRole;
@@ -87,10 +88,24 @@ public class UserAccessHandler {
     }
   }
 
+  // 비밀번호 일치 여부 체크
+  public void validatePassword(String enPassword, String password) {
+    if (!passwordEncoder.matches(password, enPassword)) {
+      throw new PasswordMismatchException();
+    }
+  }
+
   // 회원 정보 저장
   @Transactional
   public void saveUser(UserEntity user) {
     userRepository.save(user);
     log.info("saveUser -> Success");
   }
+
+  // 회원정보 삭제
+  @Transactional
+  public void deleteUser(UserEntity user) {
+    userRepository.delete(user);
+  }
 }
+

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
@@ -1,13 +1,16 @@
 package com.recipe.jamanchu.controller;
 
+import com.recipe.jamanchu.model.dto.request.auth.DeleteUserDTO;
 import com.recipe.jamanchu.model.dto.request.auth.SignupDTO;
 import com.recipe.jamanchu.model.dto.request.auth.UserUpdateDTO;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -43,9 +46,19 @@ public class UserController {
   }
 
   @PutMapping
-  public ResponseEntity<ResultResponse> updateUser(UserUpdateDTO userUpdateDTO) {
+  public ResponseEntity<ResultResponse> updateUser(HttpServletRequest request,
+      UserUpdateDTO userUpdateDTO) {
 
     return ResponseEntity.ok()
-        .body(ResultResponse.of(userService.updateUserInfo(userUpdateDTO)));
+        .body(ResultResponse.of(userService.updateUserInfo(request, userUpdateDTO)));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<ResultResponse> deleteUser(HttpServletRequest request,
+      DeleteUserDTO deleteUserDTO) {
+
+    return ResponseEntity.ok()
+        .body(ResultResponse.of(userService.deleteUser(request, deleteUserDTO)));
   }
 }
+

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/UserEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/UserEntity.java
@@ -14,12 +14,20 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Entity
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE user "
+    + "SET deleted_at = now(), "
+    + "usr_nickname = CONCAT('delete_', usr_id), "
+    + "usr_password = CONCAT('delete_', usr_id) "
+    + "WHERE usr_id = ?")
 @Table(name = "user")
 public class UserEntity extends BaseTimeEntity {
 
@@ -50,3 +58,4 @@ public class UserEntity extends BaseTimeEntity {
   @Enumerated(EnumType.STRING)
   private UserRole role;
 }
+

--- a/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/ExceptionStatus.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/ExceptionStatus.java
@@ -14,6 +14,7 @@ public enum ExceptionStatus {
   SOCIAL_ACCOUNT(HttpStatus.BAD_REQUEST, "소셜 계정은 해당 소셜 계정에서 변경 가능합니다."),
   RECIPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 레시피를 찾을 수 없습니다."),
   UNMATCHED_USER(HttpStatus.UNAUTHORIZED, "일치하는 사용자가 없습니다."),
+  PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/exception/PasswordMismatchException.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/exception/PasswordMismatchException.java
@@ -1,0 +1,11 @@
+package com.recipe.jamanchu.exceptions.exception;
+
+import com.recipe.jamanchu.exceptions.ExceptionStatus;
+
+public class PasswordMismatchException extends GlobalException{
+
+  public PasswordMismatchException() {
+
+    super(ExceptionStatus.PASSWORD_MISMATCH);
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/auth/DeleteUserDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/auth/DeleteUserDTO.java
@@ -1,0 +1,10 @@
+package com.recipe.jamanchu.model.dto.request.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteUserDTO {
+  private String password;
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/auth/UserUpdateDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/auth/UserUpdateDTO.java
@@ -7,8 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class UserUpdateDTO {
 
-  private Long userId;
-  private String password;
   private String nickname;
-
+  private String beforePassword;
+  private String afterPassword;
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
@@ -16,6 +16,7 @@ public enum ResultCode {
   SUCCESS_CR_RECIPE(HttpStatus.CREATED, "스크래핑 레시피 저장 성공!"),
   SUCCESS_UPDATE_USER_INFO(HttpStatus.OK, "회원 정보 수정 성공!"),
   SUCCESS_INSERT_CR_DATA(HttpStatus.CREATED, "데이터 분산 저장 성공!"),
+  SUCCESS_DELETE_USER(HttpStatus.OK, "회원 탈퇴 성공!")
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/UserService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/UserService.java
@@ -1,12 +1,17 @@
 package com.recipe.jamanchu.service;
 
+import com.recipe.jamanchu.model.dto.request.auth.DeleteUserDTO;
 import com.recipe.jamanchu.model.dto.request.auth.SignupDTO;
 import com.recipe.jamanchu.model.dto.request.auth.UserUpdateDTO;
 import com.recipe.jamanchu.model.type.ResultCode;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface UserService {
 
   ResultCode signup(SignupDTO signupDTO);
 
-  ResultCode updateUserInfo(UserUpdateDTO userUpdateDTO);
+  ResultCode updateUserInfo(HttpServletRequest request, UserUpdateDTO userUpdateDTO);
+
+  ResultCode deleteUser(HttpServletRequest request, DeleteUserDTO deleteUserDTO);
 }
+

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -85,7 +85,9 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     UserEntity user = userAccessHandler
         .findByUserId(jwtUtil.getUserId(request.getHeader("access-token")));
 
-    userAccessHandler.validatePassword(user.getPassword(), deleteUserDTO.getPassword());
+    if (user.getProvider() == null) {
+      userAccessHandler.validatePassword(user.getPassword(), deleteUserDTO.getPassword());
+    }
 
     userAccessHandler.deleteUser(user);
     return ResultCode.SUCCESS_DELETE_USER;

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/jwt/LoginFilterTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/jwt/LoginFilterTest.java
@@ -103,7 +103,6 @@ class LoginFilterTest {
     String password = "password";
 
     when(request.getParameter("email")).thenReturn(email);
-    when(request.getParameter("password")).thenReturn(password);
     when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
 
     PrintWriter writer = mock(PrintWriter.class);
@@ -116,7 +115,7 @@ class LoginFilterTest {
     verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
     verify(response).setContentType("application/json");
     verify(response).setCharacterEncoding("UTF-8");
-    verify(writer).write("이미 존재하는 아이디 입니다.");
+    verify(writer).write("해당 사용자를 찾을 수 없습니다.");
   }
 
   @Test
@@ -124,20 +123,20 @@ class LoginFilterTest {
   void loginValidatePassword() throws IOException {
     // given
     String email = "test@example.com";
-    String password = "1234";
+    String password = "password";
     String encodedPassword = "encodedWrongPassword";
 
     UserEntity user = UserEntity.builder()
         .userId(1L)
         .email(email)
-        .password(passwordEncoder.encode(password))
+        .password(encodedPassword)
         .role(UserRole.USER)
         .build();
 
     when(request.getParameter("email")).thenReturn(email);
-    when(request.getParameter("password")).thenReturn(password);
     when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
-    when(passwordEncoder.encode(password)).thenReturn(encodedPassword);
+    when(request.getParameter("password")).thenReturn(password);
+    when(passwordEncoder.matches(password, user.getPassword())).thenReturn(false);
 
     PrintWriter writer = mock(PrintWriter.class);
     when(response.getWriter()).thenReturn(writer);

--- a/jamanchu/src/test/java/com/recipe/jamanchu/component/UserAccessHandlerTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/component/UserAccessHandlerTest.java
@@ -9,6 +9,7 @@ import com.recipe.jamanchu.auth.oauth2.KakaoUserDetails;
 import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedEmailException;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedNicknameException;
+import com.recipe.jamanchu.exceptions.exception.PasswordMismatchException;
 import com.recipe.jamanchu.exceptions.exception.SocialAccountException;
 import com.recipe.jamanchu.exceptions.exception.UserNotFoundException;
 import com.recipe.jamanchu.repository.UserRepository;
@@ -216,6 +217,30 @@ class UserAccessHandlerTest {
 
     // when & then
     assertDoesNotThrow(() -> userAccessHandler.isSocialUser(provider));
+  }
+
+  @Test
+  @DisplayName("validatePassword - 실패 : 비밀번호 불일치")
+  void validatePassword_PasswordMisMatch() {
+    // given
+    String otherPassword = "otherPassword";
+    String userPassword = passwordEncoder.encode("userPassword");
+
+    // when & then
+    assertThrows(PasswordMismatchException.class,
+        () -> userAccessHandler.validatePassword(userPassword, otherPassword));
+  }
+
+  @Test
+  @DisplayName("validatePassword - 성공 : 비밀번호 일치")
+  void validatePassword_PasswordMatch() {
+    // given
+    String rawPassword = "password";
+    String encodedPassword = passwordEncoder.encode("password");
+    when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
+
+    // when & then
+    assertDoesNotThrow(() -> userAccessHandler.validatePassword(encodedPassword, rawPassword));
   }
 
   @Test

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -6,16 +6,20 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
+import com.recipe.jamanchu.auth.jwt.JwtUtil;
 import com.recipe.jamanchu.component.UserAccessHandler;
 import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedEmailException;
 import com.recipe.jamanchu.exceptions.exception.DuplicatedNicknameException;
+import com.recipe.jamanchu.exceptions.exception.PasswordMismatchException;
 import com.recipe.jamanchu.exceptions.exception.SocialAccountException;
 import com.recipe.jamanchu.exceptions.exception.UserNotFoundException;
+import com.recipe.jamanchu.model.dto.request.auth.DeleteUserDTO;
 import com.recipe.jamanchu.model.dto.request.auth.SignupDTO;
 import com.recipe.jamanchu.model.dto.request.auth.UserUpdateDTO;
 import com.recipe.jamanchu.model.type.ResultCode;
 import com.recipe.jamanchu.model.type.UserRole;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,27 +36,38 @@ class UserServiceImplTest {
   private UserAccessHandler userAccessHandler;
 
   @Mock
+  private JwtUtil jwtUtil;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
   private BCryptPasswordEncoder passwordEncoder;
 
   @InjectMocks
   private UserServiceImpl userServiceimpl;
 
+  private static final Long USERID = 1L;
   private static final String EMAIL = "test@email.com";
   private static final String NICKNAME = "nickname";
   private static final String PASSWORD = "1234";
   private static final String PROVIDER = "kakao";
-  private static final String NEW_PASSWORD = "newPassword";
+  private static final String BEFORE_PASSWORD = "newPassword";
+  private static final String AFTER_PASSWORD = "newPassword";
   private static final String NEW_NICKNAME = "newNickName";
 
   private SignupDTO signup;
   private UserUpdateDTO userUpdateDTO;
   private UserEntity user;
   private UserEntity kakaoUser;
+  private DeleteUserDTO deleteUserDTO;
 
   @BeforeEach
   void setUp() {
     signup = new SignupDTO(EMAIL, PASSWORD, NICKNAME);
-    userUpdateDTO = new UserUpdateDTO(1L, NEW_PASSWORD, NEW_NICKNAME);
+    userUpdateDTO = new UserUpdateDTO(BEFORE_PASSWORD, AFTER_PASSWORD, NEW_NICKNAME);
+    deleteUserDTO = new DeleteUserDTO(PASSWORD);
+
 
     // 일반 회원
     user = UserEntity.builder()
@@ -93,7 +108,8 @@ class UserServiceImplTest {
   @DisplayName("회원가입 실패 : 중복된 이메일")
   void signup_DuplicationEmail() {
     // given
-    doThrow(new DuplicatedEmailException()).when(userAccessHandler).existsByEmail(signup.getEmail());
+    doThrow(new DuplicatedEmailException()).when(userAccessHandler)
+        .existsByEmail(signup.getEmail());
 
     // when then
     assertThrows(DuplicatedEmailException.class, () -> userServiceimpl.signup(signup));
@@ -103,7 +119,8 @@ class UserServiceImplTest {
   @DisplayName("회원가입 실패 : 중복된 닉네임")
   void signup_DuplicationNickname() {
     // given
-    doThrow(new DuplicatedNicknameException()).when(userAccessHandler).existsByNickname(signup.getNickname());
+    doThrow(new DuplicatedNicknameException()).when(userAccessHandler)
+        .existsByNickname(signup.getNickname());
 
     // when then
     assertThrows(DuplicatedNicknameException.class, () -> userServiceimpl.signup(signup));
@@ -113,47 +130,125 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 성공")
   void updateUserInfo_Success() {
     // given
-    when(userAccessHandler.findByUserId(1L)).thenReturn(user);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
+
+    doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
     doNothing().when(userAccessHandler).isSocialUser(user.getProvider());
     doNothing().when(userAccessHandler).existsByNickname(userUpdateDTO.getNickname());
 
     // when
-    ResultCode result = userServiceimpl.updateUserInfo(userUpdateDTO);
+    ResultCode result = userServiceimpl.updateUserInfo(request, userUpdateDTO);
 
     // then
     assertEquals(ResultCode.SUCCESS_UPDATE_USER_INFO, result);
   }
 
   @Test
-  @DisplayName("회원정보 수정 실패 : userId가 존재하지 않은 경우")
+  @DisplayName("회원정보 수정 실패 : 존재하지 않은 회원인 경우")
   void updateUserInfo_NotFoundUser() {
     // given
-    when(userAccessHandler.findByUserId(1L)).thenThrow(new UserNotFoundException());
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
 
     // when then
-    assertThrows(UserNotFoundException.class, () -> userServiceimpl.updateUserInfo(userUpdateDTO));
+    assertThrows(UserNotFoundException.class,
+        () -> userServiceimpl.updateUserInfo(request, userUpdateDTO));
+  }
+
+  @Test
+  @DisplayName("회원정보 수정 실패 : 비밀번호가 일치하지 않은 경우")
+  void updateUserInfo_PasswordMisMatch() {
+    // given
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
+
+    doThrow(new PasswordMismatchException()).when(userAccessHandler)
+        .validatePassword(user.getPassword(), BEFORE_PASSWORD);
+
+    // when then
+    assertThrows(PasswordMismatchException.class,
+        () -> userServiceimpl.updateUserInfo(request, userUpdateDTO));
   }
 
   @Test
   @DisplayName("회원정보 수정 실패 : 카카오로 로그인을 한 회원")
   void updateUserInfo_SocialAccountException() {
     // given
-    when(userAccessHandler.findByUserId(1L)).thenReturn(kakaoUser);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(userAccessHandler.findByUserId(USERID)).thenReturn(kakaoUser);
+
+    doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
+
     doThrow(new SocialAccountException()).when(userAccessHandler).isSocialUser(kakaoUser.getProvider());
 
     // when then
-    assertThrows(SocialAccountException.class, () -> userServiceimpl.updateUserInfo(userUpdateDTO));
+    assertThrows(SocialAccountException.class,
+        () -> userServiceimpl.updateUserInfo(request, userUpdateDTO));
   }
 
   @Test
   @DisplayName("회원정보 수정 실패 : 닉네임이 중복인 경우")
   void updateUserInfo_DuplicationNickname() {
     // given
-    when(userAccessHandler.findByUserId(1L)).thenReturn(user);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
+
+    doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
     doNothing().when(userAccessHandler).isSocialUser(user.getProvider());
-    doThrow(new DuplicatedNicknameException()).when(userAccessHandler).existsByNickname(userUpdateDTO.getNickname());
+
+    doThrow(new DuplicatedNicknameException()).when(userAccessHandler)
+        .existsByNickname(userUpdateDTO.getNickname());
 
     // when then
-    assertThrows(DuplicatedNicknameException.class, () -> userServiceimpl.updateUserInfo(userUpdateDTO));
+    assertThrows(DuplicatedNicknameException.class,
+        () -> userServiceimpl.updateUserInfo(request, userUpdateDTO));
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 성공")
+  void deleteUser_Success() {
+
+    // given
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
+
+    doNothing().when(userAccessHandler)
+        .validatePassword(user.getPassword(), deleteUserDTO.getPassword());
+
+    // when
+    ResultCode result = userServiceimpl.deleteUser(request, deleteUserDTO);
+
+    // then
+    assertEquals(ResultCode.SUCCESS_DELETE_USER, result);
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 실패 : 존재하지 않은 회원인 경우")
+  void deleteUser_NotFoundUser() {
+    // given
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
+
+    // when then
+    assertThrows(UserNotFoundException.class,
+        () -> userServiceimpl.deleteUser(request, deleteUserDTO));
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 실패 : 비밀번호가 일치하지 않은 경우")
+  void deleteUser_PasswordMisMatch() {
+
+    // given
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
+
+    doThrow(new PasswordMismatchException()).when(userAccessHandler)
+        .validatePassword(user.getPassword(), deleteUserDTO.getPassword());
+
+    // when then
+    assertThrows(PasswordMismatchException.class,
+        () -> userServiceimpl.deleteUser(request, deleteUserDTO));
   }
 }
+

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -206,15 +206,29 @@ class UserServiceImplTest {
   }
 
   @Test
-  @DisplayName("회원 탈퇴 성공")
+  @DisplayName("회원 탈퇴 성공 : 일반 회원")
   void deleteUser_Success() {
 
     // given
     when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
-
     doNothing().when(userAccessHandler)
         .validatePassword(user.getPassword(), deleteUserDTO.getPassword());
+
+    // when
+    ResultCode result = userServiceimpl.deleteUser(request, deleteUserDTO);
+
+    // then
+    assertEquals(ResultCode.SUCCESS_DELETE_USER, result);
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 성공 : 소셜 가입을 한 회원")
+  void deleteUser_Success_SocialAccount() {
+
+    // given
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(userAccessHandler.findByUserId(USERID)).thenReturn(kakaoUser);
 
     // when
     ResultCode result = userServiceimpl.deleteUser(request, deleteUserDTO);
@@ -251,4 +265,3 @@ class UserServiceImplTest {
         () -> userServiceimpl.deleteUser(request, deleteUserDTO));
   }
 }
-


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
회원 탈퇴 기능 구현 및 회원정보 수정 기능 수정

 - 구현한 내용 요약
    - 구현한 클래스
	
	   - DeleteUserDTO: 회원탈퇴를 위한 데이터 클래스
	   - PasswordMismatchException: 비밀번호가 일치하지 않을 경우 발생하는 예외 처리 클래스.

    - 수정한 클래스
    
        - UserController : 회원탈퇴 및 회원정보 수정을 위한 로직 추가
           - updateUser: 회원정보 수정 처리
           - deleteUser: 회원 탈퇴 처리
              
	   - UserEntity : SQLDelete, SQLRestriction 어노테이션을 통해 소프트 삭제 처리 
	      - 삭제된 회원의 deleted_at 필드를 설정하고, 비밀번호 및 닉네임을 "delete_" + userId로 처리 (임의로 설정, 추후 수정할 예정)
	   - UserService, UserServiceImpl
	      - deleteUser: 회원탈퇴 로직을 구현. 사용자 비밀번호 검증 후 회원을 삭제 처리.
	      - updateUser: 회원정보 수정 로직 추가.
	      - 비밀번호 검증 로직과 userId 전달 방식 수정:
	         - JWT 토큰을 통해서 추출
	   - UserAccessHandler
	      - validatePassword: 비밀번호 검증 로직 추가.
	      - deleteUser: 회원 삭제 메서드 구현.
           - ResultCode : 회원탈퇴 및 회원정보 수정 관련 성공 코드 추가
              - SUCCESS_DELETE_USER: 회원탈퇴 성공
           - ExceptionStatus
              - PASSWORD_MISMATCH: 비밀번호 불일치
           - LoginFilter 
              - 응답 메시지 수정

	- 테스트 클래스
	   - UserServiceImplTest 
	      - 회원정보 수정 기능 및 회원탈퇴 기능에 대한 단위 테스트 추가 및 수정.
	   - LoginFilterTest
	      - 수정한 로직에 맞게 코드 수정.
	   - UserAccessHandlerTest
	      - 비밀번호 검증 및 회원탈퇴 로직에 대한 테스트 코드 추가.

## 스크린샷

## 주의사항

Closes #39 
