### PR TITLE
[feat] 스크랩 데이터 스케쥴링 구현

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/JamanchuApplication.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/JamanchuApplication.java
@@ -2,7 +2,9 @@ package com.recipe.jamanchu;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class JamanchuApplication {
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/ScrapTenThousandRecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/ScrapTenThousandRecipeController.java
@@ -1,7 +1,9 @@
 package com.recipe.jamanchu.controller;
 
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.scraper.ScrapTenThousandRecipe;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,12 +17,12 @@ public class ScrapTenThousandRecipeController {
   private final ScrapTenThousandRecipe recipeScrap;
 
   @GetMapping("/scrape-recipes")
-  public String scrapeRecipes(
-      @RequestParam(defaultValue = "1") int startPage,
-      @RequestParam(defaultValue = "50") int stopPage
+  public ResponseEntity<ResultResponse> scrapeRecipes(
+      @RequestParam Long startRecipeId,
+      @RequestParam Long stopRecipeId
   ) {
-    recipeScrap.scrap(startPage, stopPage);
-    return "Scraping completed!";
+    recipeScrap.scrap(startRecipeId, stopRecipeId);
+    return ResponseEntity.ok(recipeScrap.scrap(startRecipeId, stopRecipeId));
   }
 
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/TenThousandRecipeEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/TenThousandRecipeEntity.java
@@ -32,6 +32,9 @@ public class TenThousandRecipeEntity {
   @Column(name = "tr_name")
   private String name;
 
+  @Column(name = "recipe_id")
+  private Long recipeId;
+
   @Enumerated(EnumType.STRING)
   @Column(name = "tr_level")
   private LevelType levelType;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/crawling/ScrapResult.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/crawling/ScrapResult.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class ScrapResult {
 
   private String title;
+  private Long recipeId;
   private LevelType levelType;
   private CookingTimeType cookTime;
   private String thumbnail;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/TenThousandRecipeRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/TenThousandRecipeRepository.java
@@ -3,9 +3,13 @@ package com.recipe.jamanchu.repository;
 import com.recipe.jamanchu.entity.TenThousandRecipeEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TenThousandRecipeRepository extends JpaRepository<TenThousandRecipeEntity, Long> {
-  List<TenThousandRecipeEntity> findByCrawledRecipeIdBetween(Long startId, Long endId);
+  List<TenThousandRecipeEntity> findByRecipeIdBetween(Long startId, Long endId);
+
+  @Query("SELECT MAX(t.recipeId) FROM TenThousandRecipeEntity t")
+  Long findMaxRecipeId();
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/ScrapTenThousandRecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/ScrapTenThousandRecipeService.java
@@ -1,9 +1,8 @@
 package com.recipe.jamanchu.service;
 
-import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.model.dto.response.crawling.ScrapResult;
 import java.util.List;
 
 public interface ScrapTenThousandRecipeService {
-  public ResultResponse saveCrawlRecipe(List<ScrapResult> scrapResult);
+  void saveCrawlRecipe(List<ScrapResult> scrapResult);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImpl.java
@@ -1,16 +1,13 @@
 package com.recipe.jamanchu.service.impl;
 
 import com.recipe.jamanchu.entity.TenThousandRecipeEntity;
-import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.model.dto.response.crawling.ScrapResult;
-import com.recipe.jamanchu.model.type.ResultCode;
 import com.recipe.jamanchu.repository.TenThousandRecipeRepository;
 import com.recipe.jamanchu.service.ScrapTenThousandRecipeService;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,11 +16,11 @@ public class ScrapTenThousandRecipeServiceImpl implements ScrapTenThousandRecipe
   private final TenThousandRecipeRepository crawledRecipeRepository;
 
   @Override
-  @Transactional
-  public ResultResponse saveCrawlRecipe(List<ScrapResult> scrapResults) {
+  public void saveCrawlRecipe(List<ScrapResult> scrapResults) {
     crawledRecipeRepository.saveAll(scrapResults.stream()
         .map(scrapResult -> TenThousandRecipeEntity.builder()
             .name(scrapResult.getTitle())
+            .recipeId(scrapResult.getRecipeId())
             .levelType(scrapResult.getLevelType())
             .cookingTimeType(scrapResult.getCookTime())
             .ingredients(scrapResult.getIngredients())
@@ -34,7 +31,5 @@ public class ScrapTenThousandRecipeServiceImpl implements ScrapTenThousandRecipe
             .crManualPictures(scrapResult.getManualPictures())
             .build())
         .collect(Collectors.toList()));
-
-    return ResultResponse.of(ResultCode.SUCCESS_CR_RECIPE);
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/util/LastRecipeIdUtil.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/util/LastRecipeIdUtil.java
@@ -1,0 +1,14 @@
+package com.recipe.jamanchu.util;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Component
+public class LastRecipeIdUtil {
+  private Long lastRecipeId;
+}

--- a/jamanchu/src/test/java/com/recipe/jamanchu/entity/TenThousandRecipeEntityTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/entity/TenThousandRecipeEntityTest.java
@@ -26,6 +26,7 @@ class TenThousandRecipeEntityTest {
     TenThousandRecipeEntity recipeEntity = TenThousandRecipeEntity.builder()
         .crawledRecipeId(1L)
         .name("TenThousandRecipeName")
+        .recipeId(1L)
         .levelType(LOW)
         .cookingTimeType(TEN_MINUTES)
         .rating(4.50)
@@ -44,6 +45,7 @@ class TenThousandRecipeEntityTest {
     // then
     assertEquals(recipeEntity.getCrawledRecipeId(), savedRecipe.getCrawledRecipeId());
     assertEquals(recipeEntity.getName(), savedRecipe.getName());
+    assertEquals(recipeEntity.getRecipeId(), savedRecipe.getRecipeId());
     assertEquals(recipeEntity.getLevelType(), savedRecipe.getLevelType());
     assertEquals(recipeEntity.getCookingTimeType(), savedRecipe.getCookingTimeType());
     assertEquals(recipeEntity.getRating(), savedRecipe.getRating());

--- a/jamanchu/src/test/java/com/recipe/jamanchu/scraper/ScrapTenThousandRecipeTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/scraper/ScrapTenThousandRecipeTest.java
@@ -1,0 +1,117 @@
+package com.recipe.jamanchu.scraper;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import com.recipe.jamanchu.model.dto.response.crawling.ScrapResult;
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
+import com.recipe.jamanchu.repository.TenThousandRecipeRepository;
+import com.recipe.jamanchu.service.impl.ScrapTenThousandRecipeServiceImpl;
+import com.recipe.jamanchu.util.LastRecipeIdUtil;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ScrapTenThousandRecipeTest {
+
+  @Mock
+  private ScrapTenThousandRecipeServiceImpl scrapRecipeService;
+
+  @Mock
+  private TenThousandRecipeRepository tenThousandRecipeRepository;
+
+  @Mock
+  private LastRecipeIdUtil lastRecipeIdUtil;
+
+  @InjectMocks
+  private ScrapTenThousandRecipe scrapTenThousandRecipe;
+
+  @Test
+  @DisplayName("데이터 스크래핑 성공")
+  void testScrapSuccess() {
+    // Given
+    ScrapResult scrapResult1 = new ScrapResult(
+        "Test Recipe", 101L, LevelType.LOW,
+        CookingTimeType.THIRTY_MINUTES, "thumbnail", 4.5,
+        10, "ingredients", "manualContents", "manualPictures");
+    ScrapResult scrapResult2 = new ScrapResult(
+        "Test Recipe", 102L, LevelType.LOW,
+        CookingTimeType.THIRTY_MINUTES, "thumbnail", 4.0,
+        10, "ingredients", "manualContents", "manualPictures");
+
+    // When
+    ResultResponse result = scrapTenThousandRecipe.scrap(101L, 102L);
+
+    // Then
+    assertEquals("스크래핑 레시피 저장 성공!", result.getMessage());
+  }
+
+  @Test
+  @DisplayName("ScrapResult 가 중간에 null 이어도 저장이 되는 경우")
+  void testScrapWithScrapResultNull() {
+    // given
+    List<ScrapResult> scrapResults = new ArrayList<>();
+    ScrapResult scrapResult1 = new ScrapResult(
+        "Test Recipe", 101L, LevelType.LOW,
+        CookingTimeType.THIRTY_MINUTES, "thumbnail", 4.5,
+        10, "ingredients", "manualContents", "manualPictures");
+    ScrapResult scrapResult2 = null;
+    scrapResults.add(scrapResult1);
+    scrapResults.add(scrapResult2);
+
+    // 여러 레시피를 반환하도록 설정
+    ResultResponse resultResponse = scrapTenThousandRecipe.scrap(101L, 105L);
+
+    // then
+    assertNotNull(resultResponse); // 최소한 하나의 레시피가 처리되어야 하므로 null이 아니어야 함
+    assertEquals("스크래핑 레시피 저장 성공!", resultResponse.getMessage()); // 성공 코드 확인
+  }
+
+  @Test
+  @DisplayName("300개의 레시피를 스크랩할 때 2번 저장")
+  void testScrapMultipleBatches() {
+    // Given
+    List<ScrapResult> scrapResults = new ArrayList<>();
+    for (long recipeId = 1L; recipeId < 300L; recipeId++) {
+      ScrapResult scrapResult = new ScrapResult(
+          "Test Recipe", recipeId, LevelType.LOW,
+          CookingTimeType.THIRTY_MINUTES, "thumbnail", 4.5,
+          10, "ingredients", "manualContents", "manualPictures");
+      scrapResults.add(scrapResult);
+      if (recipeId == 200L) {
+        scrapRecipeService.saveCrawlRecipe(scrapResults);
+      }
+    }
+
+    // When
+    scrapRecipeService.saveCrawlRecipe(scrapResults);
+
+    // Then
+    verify(scrapRecipeService, times(2)).saveCrawlRecipe(scrapResults);
+  }
+
+  @Test
+  @DisplayName("스케쥴링 함수 정상 동작")
+  void testWeeklyRecipeScrape() {
+    // given
+    when(tenThousandRecipeRepository.findMaxRecipeId()).thenReturn(100L);
+
+    // when
+    scrapTenThousandRecipe.weeklyRecipeScrape();
+
+    // then
+    verify(tenThousandRecipeRepository).findMaxRecipeId();
+    verify(lastRecipeIdUtil).setLastRecipeId(100L);
+  }
+}

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/ScrapTenThousandRecipeServiceImplTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.model.dto.response.crawling.ScrapResult;
 import com.recipe.jamanchu.model.type.CookingTimeType;
 import com.recipe.jamanchu.model.type.LevelType;
@@ -34,22 +33,40 @@ class ScrapTenThousandRecipeServiceImplTest {
 
     // given
     ScrapResult scrapResult1 = new ScrapResult(
-        "Recipe 1", LevelType.LOW, CookingTimeType.FIFTEEN_MINUTES, "recipe1.jpg",
+        "Recipe 1", 1L, LevelType.LOW, CookingTimeType.FIFTEEN_MINUTES, "recipe1.jpg",
         4.5, 14, "Eggs, Butter", "Step 1, Step 2",
         "step1.jpg, step2.jpg");
 
     ScrapResult scrapResult2 = new ScrapResult(
-        "Recipe 2", LevelType.MEDIUM, CookingTimeType.THIRTY_MINUTES, "recipe2.jpg",
+        "Recipe 2", 2L, LevelType.MEDIUM, CookingTimeType.THIRTY_MINUTES, "recipe2.jpg",
         4.7, 5,"Chicken, Garlic", "Step 1, Step 2",
         "step1.jpg, step2.jpg");
 
     List<ScrapResult> scrapResults = Arrays.asList(scrapResult1, scrapResult2);
 
     // when
-    ResultResponse resultResponse = scrapTenThousandRecipeService.saveCrawlRecipe(scrapResults);
+    scrapTenThousandRecipeService.saveCrawlRecipe(scrapResults);
 
     // Then
-    assertEquals("스크래핑 레시피 저장 성공!", resultResponse.getMessage());
+    assertEquals(scrapResult1.getTitle(), scrapResults.get(0).getTitle());
+    assertEquals(scrapResult1.getRecipeId(), scrapResults.get(0).getRecipeId());
+    assertEquals(scrapResult1.getLevelType(), scrapResults.get(0).getLevelType());
+    assertEquals(scrapResult1.getCookTime(), scrapResults.get(0).getCookTime());
+    assertEquals(scrapResult1.getRating(), scrapResults.get(0).getRating());
+    assertEquals(scrapResult1.getReviewCount(), scrapResults.get(0).getReviewCount());
+    assertEquals(scrapResult1.getIngredients(), scrapResults.get(0).getIngredients());
+    assertEquals(scrapResult1.getManualContents(), scrapResults.get(0).getManualContents());
+    assertEquals(scrapResult1.getManualPictures(), scrapResults.get(0).getManualPictures());
+    assertEquals(scrapResult2.getTitle(), scrapResults.get(1).getTitle());
+    assertEquals(scrapResult2.getRecipeId(), scrapResults.get(1).getRecipeId());
+    assertEquals(scrapResult2.getLevelType(), scrapResults.get(1).getLevelType());
+    assertEquals(scrapResult2.getCookTime(), scrapResults.get(1).getCookTime());
+    assertEquals(scrapResult2.getRating(), scrapResults.get(1).getRating());
+    assertEquals(scrapResult2.getReviewCount(), scrapResults.get(1).getReviewCount());
+    assertEquals(scrapResult2.getIngredients(), scrapResults.get(1).getIngredients());
+    assertEquals(scrapResult2.getManualContents(), scrapResults.get(1).getManualContents());
+    assertEquals(scrapResult2.getManualPictures(), scrapResults.get(1).getManualPictures());
+
 
     // verify
     verify(tenThousandRecipeRepository, times(1)).saveAll(anyList());


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 데이터 스크래핑 시 구현 방법 수정
  - 페이징 단위에서 recipeId 단위로 수정
  - 한번에 200개의 레시피 단위로 db에 저장
- 스케쥴링 구현을 위해 Application 에 EnableScheduling 어노테이션 추가
  - 맨 처음에는 api에서 강제로 호출해서 1번부터 최신 recipeId(만개의 레시피 사이트의 id)까지 수동으로 저장
  - 그 이후에 스크래핑 스케쥴링을 통해서 일주일에 한번 새로운 데이터 불러오도록 구현
  - 매주 일요일 밤 00시에 기존 db에 없는 새로운 데이터만 가져오도록 구현
  - ten_recipe 테이블에서 가장 높은 recipeId를 찾고, recipeId를 따로 저장
    - 새로 추가 된 데이터(레시피)만 나머지 테이블에 분산 저장할 때 쓰기 위함
  - 기존 저장된 데이터의 recipeId 보다 1 높은 숫자부터 200개의 데이터를 가져오도록 구현
  - 그리고 매주 일요일 밤 0시 30분에 새로 가져온 데이터(레시피)에 대해서 분산 저장 스케쥴링 동작
- 새로운 데이터를 가져오고, 분산 저장하는 부분에 Transactional은 불필요하다고 판단되어 제거
- 테스트는 매 분 가져오는 것으로 진행
  - 데이터를 잘 가져오고, 분산 저장하는 것까지 확인 완료

## 스크린샷

## 주의사항

Closes #45 