### PR TITLE
[feat] 회원정보 조회 기능 구현

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -75,6 +75,8 @@ public class JwtFilter extends OncePerRequestFilter {
   // access 토큰이 만료되었을 경우 refresh 토큰 검증 후 재 발급
   private void expiredAccessToken(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
+
+    logger.info("Access-Token is Expired!!");
     String refreshToken = getRefreshTokenFromCookies(request);
 
     if (refreshToken == null) {
@@ -116,6 +118,9 @@ public class JwtFilter extends OncePerRequestFilter {
 
   // access 토큰 재발급
   private String createNewAccessToken(String refreshToken) {
+
+    logger.info("Create New Access-Token!");
+
     Long userId = jwtUtil.getUserId(refreshToken);
     UserRole role = UserRole.valueOf(jwtUtil.getRole(refreshToken));
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
@@ -26,6 +26,7 @@ public class UserController {
   private static final Logger log = LoggerFactory.getLogger(UserController.class);
   private final UserService userService;
 
+  // 회원 가입
   @PostMapping("/signup")
   public ResponseEntity<ResultResponse> signup(SignupDTO signupDTO) {
 
@@ -33,6 +34,7 @@ public class UserController {
         .body(ResultResponse.of(userService.signup(signupDTO)));
   }
 
+  // OAuth signup & login from Kakao
   @GetMapping("/test")
   public ResponseEntity<?> test(@RequestParam("access") String access,
       @RequestParam("refresh") String refresh) {
@@ -45,6 +47,7 @@ public class UserController {
     return ResponseEntity.ok().body("로그인 성공");
   }
 
+  // 회원 정보 수정
   @PutMapping
   public ResponseEntity<ResultResponse> updateUser(HttpServletRequest request,
       UserUpdateDTO userUpdateDTO) {
@@ -53,12 +56,21 @@ public class UserController {
         .body(ResultResponse.of(userService.updateUserInfo(request, userUpdateDTO)));
   }
 
+  // 회원 탈퇴
   @DeleteMapping
   public ResponseEntity<ResultResponse> deleteUser(HttpServletRequest request,
       DeleteUserDTO deleteUserDTO) {
 
     return ResponseEntity.ok()
         .body(ResultResponse.of(userService.deleteUser(request, deleteUserDTO)));
+  }
+
+  // 회원 정보 조회
+  @GetMapping
+  public ResponseEntity<ResultResponse> getUserInfo(HttpServletRequest request) {
+
+    return ResponseEntity.ok()
+        .body(userService.getUserInfo(request));
   }
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/auth/UserInfoDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/auth/UserInfoDTO.java
@@ -1,0 +1,11 @@
+package com.recipe.jamanchu.model.dto.response.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoDTO {
+  private String email;
+  private String nickname;
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
@@ -16,7 +16,8 @@ public enum ResultCode {
   SUCCESS_CR_RECIPE(HttpStatus.CREATED, "스크래핑 레시피 저장 성공!"),
   SUCCESS_UPDATE_USER_INFO(HttpStatus.OK, "회원 정보 수정 성공!"),
   SUCCESS_INSERT_CR_DATA(HttpStatus.CREATED, "데이터 분산 저장 성공!"),
-  SUCCESS_DELETE_USER(HttpStatus.OK, "회원 탈퇴 성공!")
+  SUCCESS_DELETE_USER(HttpStatus.OK, "회원 탈퇴 성공!"),
+  SUCCESS_GET_USER_INFO(HttpStatus.OK, "회원 정보 조회 성공!")
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/UserService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/UserService.java
@@ -3,6 +3,7 @@ package com.recipe.jamanchu.service;
 import com.recipe.jamanchu.model.dto.request.auth.DeleteUserDTO;
 import com.recipe.jamanchu.model.dto.request.auth.SignupDTO;
 import com.recipe.jamanchu.model.dto.request.auth.UserUpdateDTO;
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.model.type.ResultCode;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -13,5 +14,7 @@ public interface UserService {
   ResultCode updateUserInfo(HttpServletRequest request, UserUpdateDTO userUpdateDTO);
 
   ResultCode deleteUser(HttpServletRequest request, DeleteUserDTO deleteUserDTO);
+
+  ResultResponse getUserInfo(HttpServletRequest request);
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.recipe.jamanchu.service.impl;
 
+import static com.recipe.jamanchu.model.type.ResultCode.SUCCESS_GET_USER_INFO;
+
 import com.recipe.jamanchu.auth.jwt.JwtUtil;
 import com.recipe.jamanchu.component.UserAccessHandler;
 import com.recipe.jamanchu.entity.UserEntity;
@@ -7,6 +9,8 @@ import com.recipe.jamanchu.model.dto.request.auth.DeleteUserDTO;
 import com.recipe.jamanchu.model.dto.request.auth.SignupDTO;
 import com.recipe.jamanchu.model.dto.request.auth.UserDetailsDTO;
 import com.recipe.jamanchu.model.dto.request.auth.UserUpdateDTO;
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import com.recipe.jamanchu.model.dto.response.auth.UserInfoDTO;
 import com.recipe.jamanchu.model.type.ResultCode;
 import com.recipe.jamanchu.model.type.UserRole;
 import com.recipe.jamanchu.service.UserService;
@@ -91,6 +95,16 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
     userAccessHandler.deleteUser(user);
     return ResultCode.SUCCESS_DELETE_USER;
+  }
+
+
+  @Override
+  public ResultResponse getUserInfo(HttpServletRequest request) {
+    UserEntity user = userAccessHandler
+        .findByUserId(jwtUtil.getUserId(request.getHeader("access-token")));
+
+    return new ResultResponse(SUCCESS_GET_USER_INFO,
+        new UserInfoDTO(user.getEmail(), user.getNickname()));
   }
 }
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
회원 정보 조회 기능 구현
 - 회원 정보 조회는 우선 API명세서 기준으로 구현을 하였습니다. 

  - 구현한 내용 요약
     - 구현한 클래스
        - UserInfoDTO : 사용자에게 보여줄 회원 정보 데이터를 다루는 클래스
           - email, nickname

     - 수정한 클래스
        - UserController : 회원 정보 조회 메서드 추가
           - getUserInfo()
        - UserService & UserServiceimpl : 회원정보 조회 로직 구현
           -  Jwt 토큰에서 userId값 추출, 사용자 검증 로직 후 존재한다면 email, nickname 반환
           - 존재하지 않으면 UserNotFoundException 발생
        - ResultCode : 회원 정보 조회 성공 코드 추가
           - SUCCESS_GET_USER_INFO(HttpStatus.OK, "회원 정보 조회 성공!")
     - 테스트 코드
        - 회원정보 조회 테스트 코드 구현
           - getUserInfo_Success : 회원 정보 조회 성공
           - getUserInfo_NotFoundUser : 회원 정보 조회 실패 : 존재하지 않은 사용자 
## 스크린샷

## 주의사항

Closes #53 
