### PR TITLE
[refactor] Bussiness test code

### DIFF
--- a/jamanchu/build.gradle
+++ b/jamanchu/build.gradle
@@ -78,6 +78,20 @@ jacocoTestReport {
 		html.required = true
 		csv.required = false
 	}
+	afterEvaluate {
+		classDirectories.setFrom(
+				files(classDirectories.files.collect {
+					fileTree(dir: it, excludes : [
+							'com/recipe/jamanchu/JamanchuApplication.class',
+							'com/recipe/jamanchu/exceptions/**',
+							'com/recipe/jamanchu/util/**',
+							'com/recipe/jamanchu/model/type/**',
+							'com/recipe/jamanchu/model/dto/response/**',
+							'com/recipe/jamanchu/notify/**'
+					])
+				})
+		)
+	}
 }
 
 jacocoTestCoverageVerification {
@@ -91,6 +105,20 @@ jacocoTestCoverageVerification {
 				minimum = 0.90
 			}
 		}
+	}
+	afterEvaluate {
+		classDirectories.setFrom(
+				files(classDirectories.files.collect {
+					fileTree(dir: it, excludes : [
+							'com/recipe/jamanchu/JamanchuApplication.class',
+							'com/recipe/jamanchu/exceptions/**',
+							'com/recipe/jamanchu/util/**',
+							'com/recipe/jamanchu/model/type/**',
+							'com/recipe/jamanchu/model/dto/response/**',
+							'com/recipe/jamanchu/notify/**'
+					])
+				})
+		)
 	}
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/component/UserAccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/component/UserAccessHandler.java
@@ -55,6 +55,14 @@ public class UserAccessHandler {
             .build()));
   }
 
+  public void existsById(Long userId) {
+    log.info("existsById -> userId : {}", userId);
+    if (!userRepository.existsById(userId)) {
+      log.info("User Not Found!");
+      throw new UserNotFoundException();
+    }
+  }
+
   // 이메일 중복 체크
   public void existsByEmail(String email){
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/NotifyServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/NotifyServiceImpl.java
@@ -22,7 +22,7 @@ public class NotifyServiceImpl implements NotifyService {
   @Override
   public void subscribe(Long recipeId, FluxSink<Notify> sink) {
     if(!recipeRepository.existsById(recipeId)){
-      sink.error(new IllegalArgumentException("Recipe not found"));
+      sink.error(new RecipeNotFoundException());
       throw new RecipeNotFoundException();
     }else{
       subscribers.put(recipeId, sink);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/NotifyServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/NotifyServiceImpl.java
@@ -1,6 +1,9 @@
 package com.recipe.jamanchu.service.impl;
 
+import com.recipe.jamanchu.component.UserAccessHandler;
+import com.recipe.jamanchu.exceptions.exception.RecipeNotFoundException;
 import com.recipe.jamanchu.model.dto.response.notify.Notify;
+import com.recipe.jamanchu.repository.RecipeRepository;
 import com.recipe.jamanchu.service.NotifyService;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -11,16 +14,26 @@ import reactor.core.publisher.FluxSink;
 @Service
 public class NotifyServiceImpl implements NotifyService {
 
+  private final RecipeRepository recipeRepository;
+  private final UserAccessHandler userAccessHandler;
   private final Map<Long, FluxSink<Notify>> subscribers;
 
+  // 레시피 아이디 구독
   @Override
   public void subscribe(Long recipeId, FluxSink<Notify> sink) {
-    subscribers.put(recipeId, sink);
-    sink.onCancel(() -> subscribers.remove(recipeId));
+    if(!recipeRepository.existsById(recipeId)){
+      sink.error(new IllegalArgumentException("Recipe not found"));
+      throw new RecipeNotFoundException();
+    }else{
+      subscribers.put(recipeId, sink);
+      sink.onCancel(() -> subscribers.remove(recipeId));
+    }
   }
 
+  // 알림 전송
   @Override
   public void notifyUser(Long userId, Notify notify) {
+    userAccessHandler.existsById(userId);
     FluxSink<Notify> sink = subscribers.get(userId);
     if (sink != null) {
       sink.next(notify);

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
@@ -97,6 +97,42 @@ class CommentsServiceImplTest {
     verify(notifyService,times(1)).notifyUser(any(),any());
   }
 
+  @DisplayName("댓글 작성 테스트 - 크롤링된 데이터인 경우")
+  @Test
+  void writeCommentForCrawlingRecipe() {
+
+    // given
+    Long userId = 1L;
+
+    UserEntity user = UserEntity.builder()
+        .userId(userId)
+        .nickname("heesang")
+        .email("test@gmail.com")
+        .password("1234")
+        .role(UserRole.USER)
+        .provider(null)
+        .providerId(null)
+        .build();
+
+    Long recipeId = 1L;
+
+    RecipeEntity recipe = RecipeEntity.builder()
+        .user(user)
+        .id(recipeId)
+        .provider(RecipeProvider.SCRAP)
+        .build();
+    CommentsDTO requestDTO = new CommentsDTO(recipeId, "댓글 내용", 5.0);
+
+    // when
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
+    when(userAccessHandler.findByUserId(userId)).thenReturn(user);
+    when(recipeRepository.findById(recipeId)).thenReturn(Optional.of(recipe));
+
+    // then
+    assertEquals("댓글 작성 성공!", commentService.writeComment(request, requestDTO).getMessage());
+    verify(notifyService,times(0)).notifyUser(any(),any());
+  }
+
   @DisplayName("댓글 수정 테스트")
   @Test
   void updateComment() {

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
@@ -3,6 +3,8 @@ package com.recipe.jamanchu.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.recipe.jamanchu.auth.jwt.JwtUtil;
@@ -15,6 +17,7 @@ import com.recipe.jamanchu.model.dto.request.comments.CommentsDTO;
 import com.recipe.jamanchu.model.dto.request.comments.CommentsDeleteDTO;
 import com.recipe.jamanchu.model.dto.request.comments.CommentsUpdateDTO;
 import com.recipe.jamanchu.model.dto.response.comments.Comments;
+import com.recipe.jamanchu.model.dto.response.notify.Notify;
 import com.recipe.jamanchu.model.type.UserRole;
 import com.recipe.jamanchu.repository.CommentRepository;
 import com.recipe.jamanchu.repository.RecipeRepository;
@@ -39,6 +42,9 @@ class CommentsServiceImplTest {
 
   @Mock
   private UserAccessHandler userAccessHandler;
+
+  @Mock
+  private NotifyServiceImpl notifyService;
 
   @Mock
   private JwtUtil jwtUtil;
@@ -69,9 +75,17 @@ class CommentsServiceImplTest {
     Long recipeId = 1L;
 
     RecipeEntity recipe = RecipeEntity.builder()
+        .user(user)
         .id(recipeId)
         .build();
     CommentsDTO requestDTO = new CommentsDTO(recipeId, "댓글 내용", 5.0);
+
+    Notify notify = Notify.of(
+        recipe.getName(),
+        requestDTO.getComment(),
+        requestDTO.getRating(),
+        user.getNickname()
+    );
 
     // when
     when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
@@ -80,7 +94,7 @@ class CommentsServiceImplTest {
 
     // then
     assertEquals("댓글 작성 성공!", commentService.writeComment(request, requestDTO).getMessage());
-
+    verify(notifyService,times(1)).notifyUser(any(),any());
   }
 
   @DisplayName("댓글 수정 테스트")

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
@@ -17,7 +17,7 @@ import com.recipe.jamanchu.model.dto.request.comments.CommentsDTO;
 import com.recipe.jamanchu.model.dto.request.comments.CommentsDeleteDTO;
 import com.recipe.jamanchu.model.dto.request.comments.CommentsUpdateDTO;
 import com.recipe.jamanchu.model.dto.response.comments.Comments;
-import com.recipe.jamanchu.model.dto.response.notify.Notify;
+import com.recipe.jamanchu.model.type.RecipeProvider;
 import com.recipe.jamanchu.model.type.UserRole;
 import com.recipe.jamanchu.repository.CommentRepository;
 import com.recipe.jamanchu.repository.RecipeRepository;
@@ -55,9 +55,9 @@ class CommentsServiceImplTest {
   @InjectMocks
   private CommentsServiceImpl commentService;
 
-  @DisplayName("댓글 작성 테스트")
+  @DisplayName("댓글 작성 테스트 - 유저가 작성한 레시피인 경우")
   @Test
-  void writeComment() {
+  void writeCommentForUserRecipe() {
 
     // given
     Long userId = 1L;
@@ -79,13 +79,6 @@ class CommentsServiceImplTest {
         .id(recipeId)
         .build();
     CommentsDTO requestDTO = new CommentsDTO(recipeId, "댓글 내용", 5.0);
-
-    Notify notify = Notify.of(
-        recipe.getName(),
-        requestDTO.getComment(),
-        requestDTO.getRating(),
-        user.getNickname()
-    );
 
     // when
     when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
@@ -249,6 +242,48 @@ class CommentsServiceImplTest {
 
     // then
     assertEquals("댓글 삭제 성공!", commentService.deleteComment(request, requestDTO).getMessage());
+  }
+
+  @DisplayName("댓글 삭제 실패 테스트 - 유저가 달라서 실패하는 경우")
+  @Test
+  void failDeleteCommentBecauseUnmatchedUser() {
+    // given
+    Long requestUserId = 2L;
+
+    UserEntity requestUser = UserEntity.builder()
+        .userId(requestUserId)
+        .nickname("heesang")
+        .email("test@gmail.com")
+        .build();
+
+    Long userId = 1L;
+
+    UserEntity user = UserEntity.builder()
+        .userId(userId)
+        .nickname("heesang")
+        .email("test@gmail.com")
+        .build();
+
+    Long commentId = 1L;
+
+    CommentEntity comment = CommentEntity.builder()
+        .user(user)
+        .recipe(any())
+        .commentContent("댓글 내용")
+        .commentLike(5.0)
+        .build();
+
+    CommentsDeleteDTO requestDTO = new CommentsDeleteDTO(commentId);
+    // when
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(requestUserId);
+    when(userAccessHandler.findByUserId(requestUserId)).thenReturn(requestUser);
+    when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+
+    // then
+    assertThrows(
+        UnmatchedUserException.class,
+        () -> commentService.deleteComment(request, requestDTO)
+    );
   }
 
   @DisplayName("레시피의 댓글 조회 테스트")

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/NotifyServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/NotifyServiceImplTest.java
@@ -1,0 +1,161 @@
+package com.recipe.jamanchu.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.recipe.jamanchu.component.UserAccessHandler;
+import com.recipe.jamanchu.exceptions.exception.RecipeNotFoundException;
+import com.recipe.jamanchu.exceptions.exception.UserNotFoundException;
+import com.recipe.jamanchu.model.dto.response.notify.Notify;
+import com.recipe.jamanchu.repository.RecipeRepository;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.Disposable;
+import reactor.core.publisher.FluxSink;
+
+@DisplayName("알림 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class NotifyServiceImplTest {
+
+  @Mock
+  private RecipeRepository recipeRepository;
+
+  @Mock
+  private UserAccessHandler userAccessHandler;
+
+  @Mock
+  private FluxSink<Notify> sink;
+
+  @Mock
+  private Map<Long, FluxSink<Notify>> subscribers;
+
+  @InjectMocks
+  private NotifyServiceImpl notifyService;
+
+  @DisplayName("레시피 아이디를 통한 알림 구독 성공")
+  @Test
+  void subscribe() {
+    // given
+    Long recipeId = 1L;
+
+    // when
+    when(recipeRepository.existsById(recipeId)).thenReturn(true);
+
+    // action
+    notifyService.subscribe(recipeId, sink);
+
+    // then
+    verify(subscribers, atLeastOnce()).put(recipeId, sink);
+    verify(sink, times(1)).onCancel(any());
+  }
+
+  @DisplayName("레시피 아이디를 통한 알림 구독 실패 : 레시피가 존재하지 않음")
+  @Test
+  void failSubscribe() {
+    // given
+    Long recipeId = 1L;
+
+    // when
+    when(recipeRepository.existsById(recipeId)).thenReturn(false);
+
+    // action
+    RecipeNotFoundException recipeNotFoundException = assertThrows(RecipeNotFoundException.class,
+        () -> notifyService.subscribe(recipeId, sink));
+
+    // then
+    assertEquals("해당 레시피를 찾을 수 없습니다.", recipeNotFoundException.getMessage());
+  }
+
+  @DisplayName("레시피 구독 취소")
+  @Test
+  void successUnsubscribe() {
+    //given
+    Long recipeId = 1L;
+
+    //when
+    when(recipeRepository.existsById(recipeId)).thenReturn(true);
+
+    doAnswer(invocation -> {
+      ((Disposable) invocation.getArgument(0)).dispose();
+      return null;
+    }).when(sink).onCancel(any(Disposable.class));
+
+    // action
+    notifyService.subscribe(recipeId, sink);
+
+    //then
+    verify(sink, times(1)).onCancel(any());
+    verify(sink).onCancel(any(Disposable.class));
+    verify(subscribers, times(1)).remove(recipeId);
+  }
+
+  @DisplayName("알림 전송 성공")
+  @Test
+  void notifyUser() {
+    // given
+    Long userId = 1L;
+    Notify notify = Notify.of("recipeName", "message", 5.0, "commentUser");
+    // when
+    doNothing().when(userAccessHandler).existsById(userId);
+    when(subscribers.get(userId)).thenReturn(sink);
+
+    // action
+    notifyService.notifyUser(userId, notify);
+
+    // then
+    verify(sink, times(1)).next(notify);
+
+  }
+
+  @DisplayName("알림 전송 실패 : 사용자를 찾을 수 없음")
+  @Test
+  void failNotifyUser() {
+    // given
+    Long userId = 1L;
+    Notify notify = Notify.of("recipeName", "message", 5.0, "commentUser");
+
+    // when
+    doThrow(UserNotFoundException.class).when(userAccessHandler).existsById(userId);
+
+    // action
+
+    // then
+    assertThrows(
+        UserNotFoundException.class,
+        () -> notifyService.notifyUser(userId, notify)
+    );
+  }
+
+  @DisplayName("알림 전송 실패 : 사용자가 구독하지 않음")
+  @Test
+  void failNotifyUser2() {
+    // given
+    Long userId = 1L;
+    Notify notify = Notify.of("recipeName", "message", 5.0, "commentUser");
+
+    // when
+    doNothing().when(userAccessHandler).existsById(userId);
+    when(subscribers.get(userId)).thenReturn(null);
+
+    // action
+
+    // then
+    notifyService.notifyUser(userId, notify);
+    assertNull(subscribers.get(userId));
+    verify(sink, times(0)).next(notify);
+  }
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
### 테스트코드 관련
* Jacoco Test Coverage 제외경로 추가(Response dto, root 경로 Application, etc..)
* 댓글 작성 시 알림 전송 여부 확인 테스트코드 추가
* 댓글 작성 시 크롤링된 레시피면 알림을 전송하지 않는 로직 테스트 코드 추가
* 댓글 삭제 시 실패하는 케이스 테스트 코드 추가
* 유저 개인 정보 수정 시 패스워드만 변경하는 로직 테스트 코드 추가
* 유저 객체를 DTO로 변환하는 로직 테스트 코드 추가
* 레시피 아이디를 통한 알림 구동 성공 테스트
* 레시피 아이디를 통한 알림 구독 실패 테스트 
    * 레시피가 존재하지 않는 경우
* 레시피 구독 취소 시 발생하는 onCancel 람다 메서드 테스트
* 알림 전송 성공 테스트
* 알림 전송 실패 테스트
    * 사용자를 찾을 수 없는 경우
    * 사용자가 구독하지 않는 경우
 
### 새로 추가한 메서드
* UserAccessHandler
    * existsById
         * 특정 id를 갖는 유저가 존재하는 지 확인하는 메서드. 존재 하지 않는 경우, UserNotFoundException을 던진다.


### 새로 추가한 로직
* 알림 서비스
    * 레시피 아이디 없는 경우 예외 처리
    * 사용자가 없는 경우 예외 처리
    * 레시피 등록자가 레시피 댓글 알림을 구독하지 않은 경우 예외처리
 
## 스크린샷

## 주의사항

Closes #55 
