### PR TITLE
[refactor] OAuth2SuccessHandler redirect URI 경로 변경 및 로그 위치 변경

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -32,10 +32,10 @@ public class JwtFilter extends OncePerRequestFilter {
       throws ServletException, IOException {
 
     String requestURI = request.getRequestURI();
+    logger.info("requestURI -> {}", requestURI);
 
     // 인증이 필요 없는 경로
     if (isExcludedPath(requestURI)) {
-      logger.info("requestURI -> {}", requestURI);
       filterChain.doFilter(request, response);
       return;
     }
@@ -44,7 +44,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     // Bearer 토큰이 헤더에 있는지 확인
     if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-      logger.info("Authorization header is missing or doesn't start with Bearer");
+      logger.info("Access-token is null or doesn't start with Bearer");
       filterChain.doFilter(request, response);
       return;
     }
@@ -75,7 +75,6 @@ public class JwtFilter extends OncePerRequestFilter {
   // access 토큰이 만료되었을 경우 refresh 토큰 검증 후 재 발급
   private void expiredAccessToken(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
-
     logger.info("Access-Token is Expired!!");
     String refreshToken = getRefreshTokenFromCookies(request);
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -40,13 +40,15 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     response.addCookie(createCookie(refresh));
 
     log.info("OAuth 로그인 성공");
-    String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/api/v1/users/test")
+    String targetUrl = UriComponentsBuilder.fromUriString("https://api.jamanchu.site/api/v1/users/test")
+//    String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/api/v1/users/test")
         .queryParam("access", "Bearer " + access)
         .queryParam("refresh", refresh)
         .build()
         .toUriString();
 
-    log.info("redirect -> http://localhost:8080/api/v1/users/test");
+    log.info("redirect -> https://api.jamanchu.site/api/v1/users/test");
+//    log.info("redirect -> http://localhost:8080/api/v1/users/test");
     getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/WebMvcConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/WebMvcConfig.java
@@ -17,7 +17,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     registry.addMapping("/**") // CORS 설정을 모든 URL에 적용
 
         .allowedOrigins(
-            "https://test-jamanchu.vercel.app"
+            "https://frontend-dun-eight-78.vercel.app/"
         )
         .allowedMethods(ALLOW_METHOD_NAMES.split(","))  // 허용할 HTTP Method 목록
         .allowedHeaders("*")        // 모든 HTTP header 허용

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
@@ -32,8 +32,8 @@ public class UserController {
   @PostMapping("/signup")
   public ResponseEntity<ResultResponse> signup(@Valid @RequestBody SignupDTO signupDTO) {
 
-    return ResponseEntity.ok()
-        .body(ResultResponse.of(userService.signup(signupDTO)));
+    ResultResponse response = ResultResponse.of(userService.signup(signupDTO));
+    return ResponseEntity.status(response.getCode()).body(response);
   }
 
   // OAuth signup & login from Kakao


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
OAuth2SuccessHandler redirect URI 경로 변경 및 로그 위치 변경 하였습니다.

- 수성한 클래스
   -  OAuth2SuccessHandler
      - targetUrl : http://localhost:8080/api/v1/users/test -> https://api.jamanchu.site/api/v1/users/test 변경
      - 주석 : 개인 로컬 서버에서 테스트 할 경우 해당 경로로 실행
      
   - JwtFilter 
      - requestURI 출력 로그 위치 변경 하였습니다.

- api.jamanchu.site 서버를 활용할경우 secert.yml 파일도 같이 수정해야 합니다.   
## 스크린샷

## 주의사항

Closes #60 
