### PR TITLE
[feat] 레시피 관련 API 작성

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -63,7 +63,8 @@ public class SecurityConfig {
                 "/api/v1/users/signup",
                 "/api/v1/users/login",
                 "/api/v1/users/test",
-                "/api/v1/notify/**").permitAll()
+                "/api/v1/notify/**",
+                "/api/v1/recipes/**").permitAll()
             .anyRequest().authenticated());
 
     http

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/DataSaveController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/DataSaveController.java
@@ -20,9 +20,6 @@ public class DataSaveController {
   public ResponseEntity<ResultResponse> processAndSaveRecipes(
       @RequestParam Long startId,
       @RequestParam Long endId) {
-
-    recipeDivideService.processAndSaveAllData(startId, endId);
-
     return ResponseEntity.ok(recipeDivideService.processAndSaveAllData(startId, endId));
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -1,0 +1,36 @@
+package com.recipe.jamanchu.controller;
+
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesDeleteDTO;
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import com.recipe.jamanchu.service.RecipeService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/recipes")
+public class RecipeController {
+
+  private final RecipeService recipeService;
+
+  @PostMapping
+  public ResponseEntity<ResultResponse> registerRecipe(
+      HttpServletRequest request,
+      @RequestBody RecipesDTO recipesDTO) {
+    return ResponseEntity.ok(recipeService.registerRecipe(request, recipesDTO));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<ResultResponse> deleteRecipe(
+      HttpServletRequest request,
+      @RequestBody RecipesDeleteDTO recipesDeleteDTO) {
+    return ResponseEntity.ok(recipeService.deleteRecipe(request, recipesDeleteDTO));
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -2,15 +2,21 @@ package com.recipe.jamanchu.controller;
 
 import com.recipe.jamanchu.model.dto.request.recipe.RecipesDTO;
 import com.recipe.jamanchu.model.dto.request.recipe.RecipesDeleteDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesSearchDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesUpdateDTO;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.service.RecipeService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,24 +26,41 @@ public class RecipeController {
 
   private final RecipeService recipeService;
 
+  @GetMapping
+  public ResponseEntity<ResultResponse> getRecipes(
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "15") int size
+  ) {
+    return ResponseEntity.ok(recipeService.getRecipes(page, size));
+  }
+
+  @GetMapping("/search")
+  public ResponseEntity<ResultResponse> searchRecipes(
+      @Valid @RequestBody RecipesSearchDTO recipesSearchDTO,
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "15") int size
+  ) {
+    return ResponseEntity.ok(recipeService.searchRecipes(recipesSearchDTO, page, size));
+  }
+
   @PostMapping
   public ResponseEntity<ResultResponse> registerRecipe(
       HttpServletRequest request,
-      @RequestBody RecipesDTO recipesDTO) {
+      @Valid @RequestBody RecipesDTO recipesDTO) {
     return ResponseEntity.ok(recipeService.registerRecipe(request, recipesDTO));
   }
 
   @PutMapping
   public ResponseEntity<ResultResponse> updateRecipe(
       HttpServletRequest request,
-      @RequestBody RecipesUpdateDTO recipesUpdateDTO) {
+      @Valid @RequestBody RecipesUpdateDTO recipesUpdateDTO) {
     return ResponseEntity.ok(recipeService.updateRecipe(request, recipesUpdateDTO));
   }
 
   @DeleteMapping
   public ResponseEntity<ResultResponse> deleteRecipe(
       HttpServletRequest request,
-      @RequestBody RecipesDeleteDTO recipesDeleteDTO) {
+      @Valid @RequestBody RecipesDeleteDTO recipesDeleteDTO) {
     return ResponseEntity.ok(recipeService.deleteRecipe(request, recipesDeleteDTO));
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,6 +42,13 @@ public class RecipeController {
       @RequestParam(value = "size", defaultValue = "15") int size
   ) {
     return ResponseEntity.ok(recipeService.searchRecipes(recipesSearchDTO, page, size));
+  }
+
+  @GetMapping("/{recipeId}")
+  public ResponseEntity<ResultResponse> getRecipeDetails(
+      @PathVariable("recipeId") Long recipeId
+  ) {
+    return ResponseEntity.ok(recipeService.getRecipeDetail(recipeId));
   }
 
   @PostMapping

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -66,6 +66,13 @@ public class RecipeController {
     return ResponseEntity.ok(recipeService.registerRecipe(request, recipesDTO));
   }
 
+  @PostMapping("/{recipeId}/scrap")
+  public ResponseEntity<ResultResponse> scrapedRecipe(
+      HttpServletRequest request,
+      @PathVariable("recipeId") Long recipeId) {
+    return ResponseEntity.ok(recipeService.scrapedRecipe(request, recipeId));
+  }
+
   @PutMapping
   public ResponseEntity<ResultResponse> updateRecipe(
       HttpServletRequest request,

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -51,6 +51,14 @@ public class RecipeController {
     return ResponseEntity.ok(recipeService.getRecipeDetail(recipeId));
   }
 
+  @GetMapping("/popular")
+  public ResponseEntity<ResultResponse> getRecipesByRating(
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "15") int size
+  ) {
+    return ResponseEntity.ok(recipeService.getRecipesByRating(page, size));
+  }
+
   @PostMapping
   public ResponseEntity<ResultResponse> registerRecipe(
       HttpServletRequest request,

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -27,6 +27,13 @@ public class RecipeController {
     return ResponseEntity.ok(recipeService.registerRecipe(request, recipesDTO));
   }
 
+  @PutMapping
+  public ResponseEntity<ResultResponse> updateRecipe(
+      HttpServletRequest request,
+      @RequestBody RecipesUpdateDTO recipesUpdateDTO) {
+    return ResponseEntity.ok(recipeService.updateRecipe(request, recipesUpdateDTO));
+  }
+
   @DeleteMapping
   public ResponseEntity<ResultResponse> deleteRecipe(
       HttpServletRequest request,

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeEntity.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -23,11 +24,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * TempRecipe
- * 다른 도메인 연관관계를 설정하기 위한 임시 레시피 테이블
- * (추후 삭제 예정)
- */
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
@@ -67,4 +63,16 @@ public class RecipeEntity extends BaseTimeEntity{
 
   @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
   private List<ManualEntity> manuals;
+
+  @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+  private List<IngredientEntity> ingredients;
+
+  @OneToOne(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+  private RecipeRatingEntity rating;
+
+  @OneToOne(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+  private RecipeIngredientMappingEntity mapping;
+
+  @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+  private List<CommentEntity> comments;
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeEntity.java
@@ -67,11 +67,11 @@ public class RecipeEntity extends BaseTimeEntity{
   @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
   private List<IngredientEntity> ingredients;
 
-  @OneToOne(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-  private RecipeRatingEntity rating;
+  @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+  private List<RecipeRatingEntity> rating;
 
-  @OneToOne(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-  private RecipeIngredientMappingEntity mapping;
+  @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+  private List<RecipeIngredientMappingEntity> mapping;
 
   @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
   private List<CommentEntity> comments;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeEntity.java
@@ -75,4 +75,11 @@ public class RecipeEntity extends BaseTimeEntity{
 
   @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
   private List<CommentEntity> comments;
+
+  public void updateRecipe(String name, LevelType level, CookingTimeType time, String thumbnail) {
+    this.name = name;
+    this.level = level;
+    this.time = time;
+    this.thumbnail = thumbnail;
+  }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTO.java
@@ -2,17 +2,13 @@ package com.recipe.jamanchu.model.dto.request.recipe;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.recipe.jamanchu.entity.IngredientEntity;
-import com.recipe.jamanchu.entity.ManualEntity;
-import com.recipe.jamanchu.model.dto.response.ingredients.Ingredients;
-import com.recipe.jamanchu.model.dto.response.recipes.RecipesManuals;
+import com.recipe.jamanchu.model.dto.response.ingredients.Ingredient;
+import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
 import com.recipe.jamanchu.model.type.CookingTimeType;
 import com.recipe.jamanchu.model.type.LevelType;
-import io.swagger.v3.core.util.Json;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -32,18 +28,18 @@ public class RecipesDTO {
   private final CookingTimeType cookingTime;
 
   @JsonProperty("recipeImage")
-  private final String recipeImage;
+  private final MultipartFile recipeImage;
 
   @NotNull(message = "레시피 재료를 입력해주세요.")
   @JsonProperty("ingredients")
-  private final List<IngredientEntity> ingredients;
+  private final List<Ingredient> ingredients;
 
   @NotNull(message = "레시피 순서를 입력해주세요.")
   @JsonProperty("manuals")
-  private final List<ManualEntity> manuals;
+  private final List<RecipesManual> manuals;
 
   @JsonCreator
-  public RecipesDTO(String recipeName, LevelType level, CookingTimeType cookingTime, String recipeImage, List<IngredientEntity> ingredients, List<ManualEntity> manuals) {
+  public RecipesDTO(String recipeName, LevelType level, CookingTimeType cookingTime, MultipartFile recipeImage, List<Ingredient> ingredients, List<RecipesManual> manuals) {
     this.recipeName = recipeName;
     this.level = level;
     this.cookingTime = cookingTime;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTO.java
@@ -39,7 +39,7 @@ public class RecipesDTO {
   private final List<IngredientEntity> ingredients;
 
   @NotNull(message = "레시피 순서를 입력해주세요.")
-  @JsonProperty("orders")
+  @JsonProperty("manuals")
   private final List<ManualEntity> manuals;
 
   @JsonCreator

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTO.java
@@ -2,6 +2,8 @@ package com.recipe.jamanchu.model.dto.request.recipe;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.recipe.jamanchu.entity.IngredientEntity;
+import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.model.dto.response.ingredients.Ingredients;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesManuals;
 import com.recipe.jamanchu.model.type.CookingTimeType;
@@ -9,6 +11,7 @@ import com.recipe.jamanchu.model.type.LevelType;
 import io.swagger.v3.core.util.Json;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,23 +32,23 @@ public class RecipesDTO {
   private final CookingTimeType cookingTime;
 
   @JsonProperty("recipeImage")
-  private final MultipartFile recipeImage;
+  private final String recipeImage;
 
   @NotNull(message = "레시피 재료를 입력해주세요.")
   @JsonProperty("ingredients")
-  private final Ingredients ingredients;
+  private final List<IngredientEntity> ingredients;
 
   @NotNull(message = "레시피 순서를 입력해주세요.")
   @JsonProperty("orders")
-  private final RecipesManuals orders;
+  private final List<ManualEntity> manuals;
 
   @JsonCreator
-  public RecipesDTO(String recipeName, LevelType level, CookingTimeType cookingTime, MultipartFile recipeImage, Ingredients ingredients, RecipesManuals orders) {
+  public RecipesDTO(String recipeName, LevelType level, CookingTimeType cookingTime, String recipeImage, List<IngredientEntity> ingredients, List<ManualEntity> manuals) {
     this.recipeName = recipeName;
     this.level = level;
     this.cookingTime = cookingTime;
     this.recipeImage = recipeImage;
     this.ingredients = ingredients;
-    this.orders = orders;
+    this.manuals = manuals;
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDeleteDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDeleteDTO.java
@@ -3,7 +3,6 @@ package com.recipe.jamanchu.model.dto.request.recipe;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Min;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesSearchDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesSearchDTO.java
@@ -6,7 +6,6 @@ import com.recipe.jamanchu.annotation.AtLeastOneNotEmpty;
 import com.recipe.jamanchu.model.type.CookingTimeType;
 import com.recipe.jamanchu.model.type.LevelType;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesUpdateDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesUpdateDTO.java
@@ -2,10 +2,8 @@ package com.recipe.jamanchu.model.dto.request.recipe;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.recipe.jamanchu.entity.IngredientEntity;
-import com.recipe.jamanchu.entity.ManualEntity;
-import com.recipe.jamanchu.model.dto.response.ingredients.Ingredients;
-import com.recipe.jamanchu.model.dto.response.recipes.RecipesManuals;
+import com.recipe.jamanchu.model.dto.response.ingredients.Ingredient;
+import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
 import com.recipe.jamanchu.model.type.CookingTimeType;
 import com.recipe.jamanchu.model.type.LevelType;
 import jakarta.validation.constraints.Min;
@@ -27,9 +25,9 @@ public class RecipesUpdateDTO extends RecipesDTO{
       String recipeName,
       LevelType level,
       CookingTimeType cookingTime,
-      String recipeImage,
-      List<IngredientEntity> ingredients,
-      List<ManualEntity> manuals,
+      MultipartFile recipeImage,
+      List<Ingredient> ingredients,
+      List<RecipesManual> manuals,
       Long recipeId) {
     super(recipeName, level, cookingTime, recipeImage, ingredients, manuals);
     this.recipeId = recipeId;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesUpdateDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesUpdateDTO.java
@@ -2,12 +2,15 @@ package com.recipe.jamanchu.model.dto.request.recipe;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.recipe.jamanchu.entity.IngredientEntity;
+import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.model.dto.response.ingredients.Ingredients;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesManuals;
 import com.recipe.jamanchu.model.type.CookingTimeType;
 import com.recipe.jamanchu.model.type.LevelType;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,11 +27,11 @@ public class RecipesUpdateDTO extends RecipesDTO{
       String recipeName,
       LevelType level,
       CookingTimeType cookingTime,
-      MultipartFile recipeImage,
-      Ingredients ingredients,
-      RecipesManuals orders,
+      String recipeImage,
+      List<IngredientEntity> ingredients,
+      List<ManualEntity> manuals,
       Long recipeId) {
-    super(recipeName, level, cookingTime, recipeImage, ingredients, orders);
+    super(recipeName, level, cookingTime, recipeImage, ingredients, manuals);
     this.recipeId = recipeId;
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/ingredients/Ingredients.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/ingredients/Ingredients.java
@@ -1,15 +1,20 @@
 package com.recipe.jamanchu.model.dto.response.ingredients;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class Ingredients {
 
   @Size(min = 1, message = "재료는 최소 1개 이상이어야 합니다.")
+  @JsonProperty("ingredients")
   private final List<Ingredient> ingredients;
 
+  @JsonCreator
+  public Ingredients(List<Ingredient> ingredients) {
+    this.ingredients = ingredients;
+  }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/recipes/RecipesManual.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/recipes/RecipesManual.java
@@ -1,6 +1,5 @@
 package com.recipe.jamanchu.model.dto.response.recipes;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/recipes/RecipesManual.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/recipes/RecipesManual.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.web.multipart.MultipartFile;
 
 /**
  * 단일 레시피 조리 순서
@@ -19,6 +18,6 @@ public class RecipesManual {
   @NotEmpty(message = "조리 과정을 설명해주세요.")
   private final String recipeOrderContent;
 
-  private final MultipartFile recipeOrderImage;
+  private final String recipeOrderImage;
 
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/recipes/RecipesManual.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/recipes/RecipesManual.java
@@ -12,9 +12,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class RecipesManual {
 
-  @Min(value = 1, message = "조리 순서는 1이상이어야 합니다.")
-  private final Long recipeOrder;
-
   @NotEmpty(message = "조리 과정을 설명해주세요.")
   private final String recipeOrderContent;
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/recipes/RecipesManuals.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/recipes/RecipesManuals.java
@@ -1,18 +1,24 @@
 package com.recipe.jamanchu.model.dto.response.recipes;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
  * 레시피 조리 순서 List
  */
 @Getter
-@AllArgsConstructor
 public class RecipesManuals {
 
   @Size(min = 1, message = "조리 순서는 최소 1개 이상이어야 합니다.")
+  @JsonProperty("recipesManuals")
   private final List<RecipesManual> recipesManuals;
+
+  @JsonCreator
+  public RecipesManuals(List<RecipesManual> recipesManuals) {
+    this.recipesManuals = recipesManuals;
+  }
 
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/recipes/RecipesSummary.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/response/recipes/RecipesSummary.java
@@ -1,5 +1,7 @@
 package com.recipe.jamanchu.model.dto.response.recipes;
 
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -15,6 +17,10 @@ public class RecipesSummary {
   private final String recipeName;
 
   private final String recipeAuthor;
+
+  private final LevelType level;
+
+  private final CookingTimeType time;
 
   private final String recipeThumbnail;
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
@@ -17,7 +17,12 @@ public enum ResultCode {
   SUCCESS_UPDATE_USER_INFO(HttpStatus.OK, "회원 정보 수정 성공!"),
   SUCCESS_INSERT_CR_DATA(HttpStatus.CREATED, "데이터 분산 저장 성공!"),
   SUCCESS_DELETE_USER(HttpStatus.OK, "회원 탈퇴 성공!"),
-  SUCCESS_GET_USER_INFO(HttpStatus.OK, "회원 정보 조회 성공!")
+  SUCCESS_GET_USER_INFO(HttpStatus.OK, "회원 정보 조회 성공!"),
+  SUCCESS_REGISTER_RECIPE(HttpStatus.CREATED, "레시피 등록 성공!"),
+  SUCCESS_UPDATE_RECIPE(HttpStatus.OK, "레시피 수정 성공!"),
+  SUCCESS_DELETE_RECIPE(HttpStatus.OK, "레시피를 정상적으로 삭제하였습니다."),
+  SUCCESS_RETRIEVE_ALL_RECIPES(HttpStatus.OK, "전체 레시피 조회 성공!"),
+  SUCCESS_RETRIEVE_RECIPES(HttpStatus.OK, "레시피 조회 성공!")
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
@@ -22,7 +22,9 @@ public enum ResultCode {
   SUCCESS_UPDATE_RECIPE(HttpStatus.OK, "레시피 수정 성공!"),
   SUCCESS_DELETE_RECIPE(HttpStatus.OK, "레시피를 정상적으로 삭제하였습니다."),
   SUCCESS_RETRIEVE_ALL_RECIPES(HttpStatus.OK, "전체 레시피 조회 성공!"),
-  SUCCESS_RETRIEVE_RECIPES(HttpStatus.OK, "레시피 조회 성공!")
+  SUCCESS_RETRIEVE_RECIPES(HttpStatus.OK, "레시피 조회 성공!"),
+  SUCCESS_RETRIEVE_RECIPES_DETAILS(HttpStatus.OK, "레시피 상세 조회 성공"),
+  SUCCESS_RETRIEVE_ALL_RECIPES_BY_RATING(HttpStatus.OK, "인기 레시피 조회 성공"),
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
@@ -25,6 +25,7 @@ public enum ResultCode {
   SUCCESS_RETRIEVE_RECIPES(HttpStatus.OK, "레시피 조회 성공!"),
   SUCCESS_RETRIEVE_RECIPES_DETAILS(HttpStatus.OK, "레시피 상세 조회 성공"),
   SUCCESS_RETRIEVE_ALL_RECIPES_BY_RATING(HttpStatus.OK, "인기 레시피 조회 성공"),
+  SUCCESS_SCRAPED_RECIPE(HttpStatus.OK, "레시피 찜하기 성공"),
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/IngredientRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/IngredientRepository.java
@@ -1,10 +1,20 @@
 package com.recipe.jamanchu.repository;
 
 import com.recipe.jamanchu.entity.IngredientEntity;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface IngredientRepository extends JpaRepository<IngredientEntity, Long> {
 
+  Optional<List<IngredientEntity>> findAllByRecipeId(Long recipeId);
+
+  @Modifying
+  @Query("DELETE FROM IngredientEntity i WHERE i.recipe.id = :recipeId")
+  void deleteAllByRecipeId(@Param("recipeId") Long recipeId);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/ManualRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/ManualRepository.java
@@ -1,10 +1,20 @@
 package com.recipe.jamanchu.repository;
 
 import com.recipe.jamanchu.entity.ManualEntity;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ManualRepository extends JpaRepository<ManualEntity, Long> {
 
+  Optional<List<ManualEntity>> findAllByRecipeId(Long recipeId);
+
+  @Modifying
+  @Query("DELETE FROM ManualEntity m WHERE m.recipe.id = :recipeId")
+  void deleteAllByRecipeId(@Param("recipeId") Long recipeId);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeRepository.java
@@ -35,4 +35,10 @@ public interface RecipeRepository extends JpaRepository<RecipeEntity, Long> {
       @Param("cookingTime") CookingTimeType cookingTime,
       @Param("ingredients") List<String> ingredients,
       Pageable pageable);
+
+  @Query("SELECT r FROM RecipeEntity r " +
+      "LEFT JOIN r.rating rat " +
+      "GROUP BY r.id " +
+      "ORDER BY AVG(rat.rating) DESC")
+  Page<RecipeEntity> findAllOrderByRating(Pageable pageable);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeRepository.java
@@ -1,10 +1,38 @@
 package com.recipe.jamanchu.repository;
 
 import com.recipe.jamanchu.entity.RecipeEntity;
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecipeRepository extends JpaRepository<RecipeEntity, Long> {
 
+  @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +
+      "WHERE (:ingredients IS NULL OR ri.name IN :ingredients) " +
+      "AND (:cookingTime IS NULL OR r.time = :cookingTime) " +
+      "AND (:level IS NULL OR r.level = :level) " +
+      "GROUP BY r.id " +
+      "HAVING COUNT(ri.name) = :ingredientCount")
+  Page<RecipeEntity> searchAndRecipes(@Param("level") LevelType level,
+      @Param("cookingTime") CookingTimeType cookingTime,
+      @Param("ingredients") List<String> ingredients,
+      @Param("ingredientCount") Long ingredientCount,
+      Pageable pageable);
+
+  @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +
+      "WHERE (:level IS NULL OR r.level = :level) " +
+      "OR (:cookingTime IS NULL OR r.time = :cookingTime) " +
+      "OR (:ingredients IS NULL OR ri.name IN :ingredients) " +
+      "GROUP BY r.id")
+  Page<RecipeEntity> searchOrRecipes(@Param("level") LevelType level,
+      @Param("cookingTime") CookingTimeType cookingTime,
+      @Param("ingredients") List<String> ingredients,
+      Pageable pageable);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
@@ -1,0 +1,17 @@
+package com.recipe.jamanchu.service;
+
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesDeleteDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesSearchDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesUpdateDTO;
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface RecipeService {
+
+  // 레시피 작성 API
+  ResultResponse registerRecipe(HttpServletRequest request, RecipesDTO recipesDTO);
+
+  // 레시피 삭제 API
+  ResultResponse deleteRecipe(HttpServletRequest request, RecipesDeleteDTO recipesDeleteDTO);
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
@@ -25,6 +25,7 @@ public interface RecipeService {
   ResultResponse getRecipeDetail(Long recipesId);
 
   // 인기 레시피 리스트 API
+  ResultResponse getRecipesByRating(int page, int size);
   // 레시피 스크랩 API
 
   // 레시피 삭제 API

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
@@ -12,6 +12,9 @@ public interface RecipeService {
   // 레시피 작성 API
   ResultResponse registerRecipe(HttpServletRequest request, RecipesDTO recipesDTO);
 
+  // 레시피 수정 API
+  ResultResponse updateRecipe(HttpServletRequest request, RecipesUpdateDTO recipesUpdateDTO);
+
   // 레시피 삭제 API
   ResultResponse deleteRecipe(HttpServletRequest request, RecipesDeleteDTO recipesDeleteDTO);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
@@ -21,6 +21,12 @@ public interface RecipeService {
   // 특정 조건 레시피 조회 API
   ResultResponse searchRecipes(RecipesSearchDTO recipesSearchDTO, int page, int size);
 
+  // 레시피 상세 페이지 조회 API
+  ResultResponse getRecipeDetail(Long recipesId);
+
+  // 인기 레시피 리스트 API
+  // 레시피 스크랩 API
+
   // 레시피 삭제 API
   ResultResponse deleteRecipe(HttpServletRequest request, RecipesDeleteDTO recipesDeleteDTO);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
@@ -26,7 +26,9 @@ public interface RecipeService {
 
   // 인기 레시피 리스트 API
   ResultResponse getRecipesByRating(int page, int size);
+
   // 레시피 스크랩 API
+  ResultResponse scrapedRecipe(HttpServletRequest request, Long recipeId);
 
   // 레시피 삭제 API
   ResultResponse deleteRecipe(HttpServletRequest request, RecipesDeleteDTO recipesDeleteDTO);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
@@ -15,6 +15,12 @@ public interface RecipeService {
   // 레시피 수정 API
   ResultResponse updateRecipe(HttpServletRequest request, RecipesUpdateDTO recipesUpdateDTO);
 
+  // 모든 레시피 조회 API
+  ResultResponse getRecipes(int page, int size);
+
+  // 특정 조건 레시피 조회 API
+  ResultResponse searchRecipes(RecipesSearchDTO recipesSearchDTO, int page, int size);
+
   // 레시피 삭제 API
   ResultResponse deleteRecipe(HttpServletRequest request, RecipesDeleteDTO recipesDeleteDTO);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -161,6 +161,7 @@ public class RecipeServiceImpl implements RecipeService {
   }
 
   @Override
+  @Transactional
   public ResultResponse deleteRecipe(HttpServletRequest request,
       RecipesDeleteDTO recipesDeleteDTO) {
     Long userId = jwtUtil.getUserId(request.getHeader("access-token"));

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -1,0 +1,119 @@
+package com.recipe.jamanchu.service.impl;
+
+import static com.recipe.jamanchu.model.type.RecipeProvider.*;
+
+import com.recipe.jamanchu.auth.jwt.JwtUtil;
+import com.recipe.jamanchu.component.UserAccessHandler;
+import com.recipe.jamanchu.entity.IngredientEntity;
+import com.recipe.jamanchu.entity.ManualEntity;
+import com.recipe.jamanchu.entity.RecipeEntity;
+import com.recipe.jamanchu.entity.UserEntity;
+import com.recipe.jamanchu.exceptions.exception.RecipeNotFoundException;
+import com.recipe.jamanchu.exceptions.exception.UnmatchedUserException;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesDeleteDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesSearchDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesUpdateDTO;
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import com.recipe.jamanchu.model.dto.response.comments.Comment;
+import com.recipe.jamanchu.model.dto.response.comments.Comments;
+import com.recipe.jamanchu.model.dto.response.ingredients.Ingredient;
+import com.recipe.jamanchu.model.dto.response.ingredients.Ingredients;
+import com.recipe.jamanchu.model.dto.response.recipes.RecipesInfo;
+import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
+import com.recipe.jamanchu.model.type.ResultCode;
+import com.recipe.jamanchu.repository.IngredientRepository;
+import com.recipe.jamanchu.repository.ManualRepository;
+import com.recipe.jamanchu.repository.RecipeRepository;
+import com.recipe.jamanchu.service.RecipeService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class RecipeServiceImpl implements RecipeService {
+
+  private final RecipeRepository recipeRepository;
+  private final IngredientRepository ingredientRepository;
+  private final ManualRepository manualRepository;
+  private final UserAccessHandler userAccessHandler;
+  private final JwtUtil jwtUtil;
+
+  @Override
+  @Transactional
+  public ResultResponse registerRecipe(HttpServletRequest request, RecipesDTO recipesDTO) {
+
+    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    UserEntity user = userAccessHandler.findByUserId(userId);
+
+    RecipeEntity recipe = RecipeEntity.builder()
+        .user(user)
+        .name(recipesDTO.getRecipeName())
+        .level(recipesDTO.getLevel())
+        .time(recipesDTO.getCookingTime())
+        .thumbnail(recipesDTO.getRecipeImage())
+        .provider(USER)
+        .build();
+
+    recipeRepository.save(recipe);
+
+    List<IngredientEntity> ingredients = new ArrayList<>();
+    for (int i = 0; i < recipesDTO.getIngredients().size(); i++) {
+      IngredientEntity ingredient = IngredientEntity.builder()
+          .recipe(recipe)
+          .name(recipesDTO.getIngredients().get(i).getName())
+          .quantity(recipesDTO.getIngredients().get(i).getQuantity())
+          .build();
+
+      ingredients.add(ingredient);
+    }
+
+    ingredientRepository.saveAll(ingredients);
+
+    List<ManualEntity> manuals = new ArrayList<>();
+    for (int i = 0; i < recipesDTO.getManuals().size(); i++) {
+      ManualEntity manual = ManualEntity.builder()
+          .recipe(recipe)
+          .manualContent(recipesDTO.getManuals().get(i).getManualContent())
+          .manualPicture(recipesDTO.getManuals().get(i).getManualPicture())
+          .build();
+
+      manuals.add(manual);
+    }
+
+    manualRepository.saveAll(manuals);
+
+    return ResultResponse.of(ResultCode.SUCCESS_REGISTER_RECIPE, recipe.getId());
+  }
+
+  @Override
+  public ResultResponse deleteRecipe(HttpServletRequest request,
+      RecipesDeleteDTO recipesDeleteDTO) {
+    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+
+    UserEntity user = userAccessHandler.findByUserId(userId);
+
+    Long recipeId = recipesDeleteDTO.getRecipeId();
+
+    RecipeEntity recipe = recipeRepository.findById(recipeId)
+        .orElseThrow(RecipeNotFoundException::new);
+
+    if (!Objects.equals(user.getUserId(), recipe.getUser().getUserId())) {
+      throw new UnmatchedUserException();
+    }
+
+    recipeRepository.deleteById(recipeId);
+
+    return ResultResponse.of(ResultCode.SUCCESS_DELETE_RECIPE);
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -15,6 +15,12 @@ import com.recipe.jamanchu.model.dto.request.recipe.RecipesDeleteDTO;
 import com.recipe.jamanchu.model.dto.request.recipe.RecipesSearchDTO;
 import com.recipe.jamanchu.model.dto.request.recipe.RecipesUpdateDTO;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import com.recipe.jamanchu.model.dto.response.comments.Comment;
+import com.recipe.jamanchu.model.dto.response.comments.Comments;
+import com.recipe.jamanchu.model.dto.response.ingredients.IngredientCoupang;
+import com.recipe.jamanchu.model.dto.response.recipes.RecipesInfo;
+import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
+import com.recipe.jamanchu.model.dto.response.recipes.RecipesManuals;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesSummary;
 import com.recipe.jamanchu.model.type.ResultCode;
 import com.recipe.jamanchu.repository.IngredientRepository;
@@ -230,5 +236,50 @@ public class RecipeServiceImpl implements RecipeService {
         )).toList();
 
     return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_RECIPES, recipesSummaries);
+  }
+
+  @Override
+  public ResultResponse getRecipeDetail(Long recipeId) {
+    RecipeEntity recipe = recipeRepository.findById(recipeId)
+        .orElseThrow(RecipeNotFoundException::new);
+
+    // 추후에 이 부분 추가 개발 필요
+    String tempCoupangLink = "Coupang Link";
+
+    List<IngredientCoupang> ingredientCoupangList = recipe.getIngredients().stream()
+        .map(ingredient -> new IngredientCoupang(
+            ingredient.getName(),
+            ingredient.getQuantity(),
+            tempCoupangLink))
+        .toList();
+
+    RecipesManuals recipesManuals = new RecipesManuals(
+        recipe.getManuals().stream()
+            .map(manual -> new RecipesManual(
+                manual.getManualContent(),
+                manual.getManualPicture()
+            ))
+            .toList()
+    );
+
+    Comments comments = new Comments(
+        recipe.getComments().stream()
+            .map(Comment::new)
+            .toList()
+    );
+
+    RecipesInfo recipesInfo = new RecipesInfo(
+        recipe.getId(),
+        recipe.getUser().getNickname(),
+        recipe.getName(),
+        recipe.getLevel(),
+        recipe.getTime(),
+        recipe.getThumbnail(),
+        ingredientCoupangList,
+        recipesManuals,
+        comments
+    );
+
+    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_RECIPES, recipesInfo);
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -64,7 +64,7 @@ public class RecipeServiceImpl implements RecipeService {
         .name(recipesDTO.getRecipeName())
         .level(recipesDTO.getLevel())
         .time(recipesDTO.getCookingTime())
-        .thumbnail(recipesDTO.getRecipeImage())
+        .thumbnail(String.valueOf(recipesDTO.getRecipeImage()))
         .provider(USER)
         .build();
 
@@ -74,8 +74,8 @@ public class RecipeServiceImpl implements RecipeService {
     for (int i = 0; i < recipesDTO.getIngredients().size(); i++) {
       IngredientEntity ingredient = IngredientEntity.builder()
           .recipe(recipe)
-          .name(recipesDTO.getIngredients().get(i).getName())
-          .quantity(recipesDTO.getIngredients().get(i).getQuantity())
+          .name(recipesDTO.getIngredients().get(i).getIngredientName())
+          .quantity(recipesDTO.getIngredients().get(i).getIngredientQuantity())
           .build();
 
       ingredients.add(ingredient);
@@ -87,8 +87,8 @@ public class RecipeServiceImpl implements RecipeService {
     for (int i = 0; i < recipesDTO.getManuals().size(); i++) {
       ManualEntity manual = ManualEntity.builder()
           .recipe(recipe)
-          .manualContent(recipesDTO.getManuals().get(i).getManualContent())
-          .manualPicture(recipesDTO.getManuals().get(i).getManualPicture())
+          .manualContent(recipesDTO.getManuals().get(i).getRecipeOrderContent())
+          .manualPicture(recipesDTO.getManuals().get(i).getRecipeOrderImage())
           .build();
 
       manuals.add(manual);
@@ -118,7 +118,7 @@ public class RecipeServiceImpl implements RecipeService {
 
     recipe.updateRecipe(recipesUpdateDTO.getRecipeName(),
         recipesUpdateDTO.getLevel(), recipesUpdateDTO.getCookingTime(),
-        recipesUpdateDTO.getRecipeImage());
+        String.valueOf(recipesUpdateDTO.getRecipeImage()));
 
     // 기존 recipeId로 저장된 재료 확인
     ingredientRepository.findAllByRecipeId(recipeId)
@@ -130,8 +130,8 @@ public class RecipeServiceImpl implements RecipeService {
     for (int i = 0; i < recipesUpdateDTO.getIngredients().size(); i++) {
       IngredientEntity ingredient = IngredientEntity.builder()
           .recipe(recipe)
-          .name(recipesUpdateDTO.getIngredients().get(i).getName())
-          .quantity(recipesUpdateDTO.getIngredients().get(i).getQuantity())
+          .name(recipesUpdateDTO.getIngredients().get(i).getIngredientName())
+          .quantity(recipesUpdateDTO.getIngredients().get(i).getIngredientQuantity())
           .build();
 
       ingredients.add(ingredient);
@@ -148,8 +148,8 @@ public class RecipeServiceImpl implements RecipeService {
     for (int i = 0; i < recipesUpdateDTO.getManuals().size(); i++) {
       ManualEntity manual = ManualEntity.builder()
           .recipe(recipe)
-          .manualContent(recipesUpdateDTO.getManuals().get(i).getManualContent())
-          .manualPicture(recipesUpdateDTO.getManuals().get(i).getManualPicture())
+          .manualContent(recipesUpdateDTO.getManuals().get(i).getRecipeOrderContent())
+          .manualPicture(recipesUpdateDTO.getManuals().get(i).getRecipeOrderImage())
           .build();
 
       manuals.add(manual);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -280,6 +280,29 @@ public class RecipeServiceImpl implements RecipeService {
         comments
     );
 
-    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_RECIPES, recipesInfo);
+    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_RECIPES_DETAILS, recipesInfo);
+  }
+
+  @Override
+  public ResultResponse getRecipesByRating(int page, int size) {
+    Pageable pageable = PageRequest.of(page, size);
+
+    Page<RecipeEntity> recipes = recipeRepository.findAllOrderByRating(pageable);
+
+    if (recipes.isEmpty()) {
+      throw new RecipeNotFoundException();
+    }
+
+    List<RecipesSummary> recipesSummaries = recipes.stream().map(
+        recipeEntity -> new RecipesSummary(
+            recipeEntity.getId(),
+            recipeEntity.getName(),
+            recipeEntity.getUser().getNickname(),
+            recipeEntity.getLevel(),
+            recipeEntity.getTime(),
+            recipeEntity.getThumbnail()
+        )).toList();
+
+    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_ALL_RECIPES_BY_RATING, recipesSummaries);
   }
 }

--- a/jamanchu/src/test/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTOTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTOTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.recipe.jamanchu.entity.IngredientEntity;
+import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.model.dto.response.ingredients.Ingredient;
 import com.recipe.jamanchu.model.dto.response.ingredients.Ingredients;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
@@ -36,16 +38,13 @@ class RecipesDTOTest {
         LevelType.LOW,
         CookingTimeType.TEN_MINUTES,
         null,
-        new Ingredients(
-            List.of(
-                new Ingredient("재료 이름", "재료 양")
-            )
+        List.of(
+            IngredientEntity.builder()
+                .build()
         ),
-        new RecipesManuals(
-            List.of(
-                new RecipesManual(1L, "레시피 순서", null
-                )
-            )
+        List.of(
+            ManualEntity.builder()
+                .build()
         ));
     //when
     Set<ConstraintViolation<RecipesDTO>> violations = validator.validate(recipesDTO);

--- a/jamanchu/src/test/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTOTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTOTest.java
@@ -4,12 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.recipe.jamanchu.entity.IngredientEntity;
-import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.model.dto.response.ingredients.Ingredient;
-import com.recipe.jamanchu.model.dto.response.ingredients.Ingredients;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
-import com.recipe.jamanchu.model.dto.response.recipes.RecipesManuals;
 import com.recipe.jamanchu.model.type.CookingTimeType;
 import com.recipe.jamanchu.model.type.LevelType;
 import jakarta.validation.ConstraintViolation;
@@ -38,14 +34,15 @@ class RecipesDTOTest {
         LevelType.LOW,
         CookingTimeType.TEN_MINUTES,
         null,
-        List.of(
-            IngredientEntity.builder()
-                .build()
-        ),
-        List.of(
-            ManualEntity.builder()
-                .build()
-        ));
+            List.of(
+                new Ingredient("재료", "재료 양")
+            )
+        ,
+
+            List.of(
+                new RecipesManual("레시피 순서", "레시피 이미지")
+            )
+        );
     //when
     Set<ConstraintViolation<RecipesDTO>> violations = validator.validate(recipesDTO);
     //then

--- a/jamanchu/src/test/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesUpdateDTOTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesUpdateDTOTest.java
@@ -37,12 +37,10 @@ class RecipesUpdateDTOTest {
         CookingTimeType.TEN_MINUTES,
         null,
         List.of(
-            IngredientEntity.builder()
-                .build()
+            new Ingredient("재료", "재료 양")
         ),
         List.of(
-            ManualEntity.builder()
-                .build()
+            new RecipesManual("레시피 순서", "레시피 이미지")
         ),
         0L
     );
@@ -64,12 +62,10 @@ class RecipesUpdateDTOTest {
         CookingTimeType.TEN_MINUTES,
         null,
         List.of(
-            IngredientEntity.builder()
-                .build()
+            new Ingredient("재료", "재료 양")
         ),
         List.of(
-            ManualEntity.builder()
-                .build()
+            new RecipesManual("레시피 순서", "레시피 이미지")
         ),
         null
     );

--- a/jamanchu/src/test/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesUpdateDTOTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesUpdateDTOTest.java
@@ -2,6 +2,8 @@ package com.recipe.jamanchu.model.dto.request.recipe;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.recipe.jamanchu.entity.IngredientEntity;
+import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.model.dto.response.ingredients.Ingredient;
 import com.recipe.jamanchu.model.dto.response.ingredients.Ingredients;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
@@ -34,12 +36,14 @@ class RecipesUpdateDTOTest {
         LevelType.LOW,
         CookingTimeType.TEN_MINUTES,
         null,
-        new Ingredients(List.of(
-            new Ingredient("재료 이름", "재료 양")
-        )),
-        new RecipesManuals(List.of(
-            new RecipesManual(1L, "레시피 순서", null)
-        )),
+        List.of(
+            IngredientEntity.builder()
+                .build()
+        ),
+        List.of(
+            ManualEntity.builder()
+                .build()
+        ),
         0L
     );
 
@@ -59,12 +63,14 @@ class RecipesUpdateDTOTest {
         LevelType.LOW,
         CookingTimeType.TEN_MINUTES,
         null,
-        new Ingredients(List.of(
-            new Ingredient("재료 이름", "재료 양")
-        )),
-        new RecipesManuals(List.of(
-            new RecipesManual(1L, "레시피 순서", null)
-        )),
+        List.of(
+            IngredientEntity.builder()
+                .build()
+        ),
+        List.of(
+            ManualEntity.builder()
+                .build()
+        ),
         null
     );
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -1,0 +1,480 @@
+package com.recipe.jamanchu.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.recipe.jamanchu.auth.jwt.JwtUtil;
+import com.recipe.jamanchu.component.UserAccessHandler;
+import com.recipe.jamanchu.entity.CommentEntity;
+import com.recipe.jamanchu.entity.IngredientEntity;
+import com.recipe.jamanchu.entity.ManualEntity;
+import com.recipe.jamanchu.entity.RecipeEntity;
+import com.recipe.jamanchu.entity.RecipeRatingEntity;
+import com.recipe.jamanchu.entity.UserEntity;
+import com.recipe.jamanchu.exceptions.exception.RecipeNotFoundException;
+import com.recipe.jamanchu.exceptions.exception.UnmatchedUserException;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesDeleteDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesSearchDTO;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesUpdateDTO;
+import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import com.recipe.jamanchu.model.dto.response.recipes.RecipesInfo;
+import com.recipe.jamanchu.model.dto.response.recipes.RecipesSummary;
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
+import com.recipe.jamanchu.model.type.UserRole;
+import com.recipe.jamanchu.repository.IngredientRepository;
+import com.recipe.jamanchu.repository.ManualRepository;
+import com.recipe.jamanchu.repository.RecipeRepository;
+import com.recipe.jamanchu.repository.ScrapedRecipeRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class RecipeServiceImplTest {
+
+  @Mock
+  private RecipeRepository recipeRepository;
+
+  @Mock
+  private IngredientRepository ingredientRepository;
+
+  @Mock
+  private ManualRepository manualRepository;
+
+  @Mock
+  private ScrapedRecipeRepository scrapedRecipeRepository;
+
+  @Mock
+  private UserAccessHandler userAccessHandler;
+
+  @Mock
+  private JwtUtil jwtUtil;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @InjectMocks
+  private RecipeServiceImpl recipeService;
+
+  private UserEntity user;
+  private List<ManualEntity> manuals;
+  private List<IngredientEntity> ingredients;
+  private RecipeRatingEntity rating;
+  private RecipeEntity recipe;
+  private RecipesDTO recipesDTO;
+  private RecipesUpdateDTO recipesUpdateDTO;
+
+  @BeforeEach
+  void setUp() {
+    user = UserEntity.builder()
+        .userId(1L)
+        .email("test@example.com")
+        .nickname("nickname")
+        .password("password")
+        .role(UserRole.USER)
+        .provider(null)
+        .providerId(null)
+        .build();
+
+    ingredients = new ArrayList<>();
+    ingredients.add(IngredientEntity.builder()
+        .name("돼지고기")
+        .quantity("200g")
+        .build());
+
+    ingredients.add(IngredientEntity.builder()
+        .name("달걀")
+        .quantity("2개")
+        .build());
+
+    manuals = new ArrayList<>();
+    manuals.add(ManualEntity.builder()
+        .manualContent("고기를 구워주세요.")
+        .manualPicture("manual_picture_1.jpg")
+        .build());
+
+    manuals.add(ManualEntity.builder()
+        .manualContent("달걀을 삶아주세요.")
+        .manualPicture("manual_picture_2.jpg")
+        .build());
+
+    recipesDTO = new RecipesDTO(
+        "recipeName",
+        LevelType.LOW,
+        CookingTimeType.FIFTEEN_MINUTES,
+        "thumbnail",
+        ingredients,
+        manuals
+    );
+
+    recipesUpdateDTO = new RecipesUpdateDTO(
+        "recipeUpdateName",
+        LevelType.LOW,
+        CookingTimeType.TEN_MINUTES,
+        "thumbnail.jpg",
+        ingredients,
+        manuals,
+        1L
+    );
+
+    recipe = RecipeEntity.builder()
+        .id(1L)
+        .user(user)
+        .name(recipesDTO.getRecipeName())
+        .level(recipesDTO.getLevel())
+        .time(recipesDTO.getCookingTime())
+        .thumbnail(recipesDTO.getRecipeImage())
+        .ingredients(recipesDTO.getIngredients())
+        .manuals(recipesDTO.getManuals())
+        .build();
+  }
+
+  @Test
+  @DisplayName("레시피 등록 성공")
+  void registerRecipe_Success() {
+    // given
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
+
+    // when
+    ResultResponse result = recipeService.registerRecipe(request, recipesDTO);
+
+    // then
+    assertEquals("레시피 등록 성공!", result.getMessage());
+
+    // verify
+    verify(recipeRepository, times(1)).save(any(RecipeEntity.class));
+    verify(ingredientRepository, times(1)).saveAll(anyList());
+    verify(manualRepository, times(1)).saveAll(anyList());
+  }
+
+  @Test
+  @DisplayName("레시피 수정 성공")
+  void updateRecipe_Success() {
+    // Given
+    recipe = RecipeEntity.builder()
+        .id(1L)
+        .user(user)
+        .name(recipesDTO.getRecipeName())
+        .level(recipesDTO.getLevel())
+        .time(recipesDTO.getCookingTime())
+        .thumbnail(recipesDTO.getRecipeImage())
+        .ingredients(recipesDTO.getIngredients())
+        .manuals(recipesDTO.getManuals())
+        .build();
+
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(userAccessHandler.findByUserId(1L)).thenReturn(user);
+    when(recipeRepository.findById(1L)).thenReturn(Optional.of(recipe));
+    when(ingredientRepository.findAllByRecipeId(1L)).thenReturn(Optional.of(ingredients));
+    when(manualRepository.findAllByRecipeId(1L)).thenReturn(Optional.of(manuals));
+
+    // When
+    ResultResponse result = recipeService.updateRecipe(request, recipesUpdateDTO);
+
+    // Then
+    assertEquals("레시피 수정 성공!", result.getMessage());
+
+    // verify
+    verify(recipeRepository, times(1)).findById(1L);
+    verify(ingredientRepository, times(1)).deleteAllByRecipeId(1L);
+    verify(ingredientRepository, times(1)).saveAll(anyList());
+    verify(manualRepository, times(1)).deleteAllByRecipeId(1L);
+    verify(manualRepository, times(1)).saveAll(anyList());
+  }
+
+  @Test
+  @DisplayName("레시피 수정 실패 - 등록한 유저와 수정하는 유저가 다를 때")
+  void updateRecipe_FailUnMatchedUser() {
+    // given
+    UserEntity requestUser = UserEntity.builder()
+        .userId(2L)
+        .build();
+
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(2L);
+    when(userAccessHandler.findByUserId(requestUser.getUserId())).thenReturn(requestUser);
+    when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.ofNullable(recipe));
+
+    // when & then
+    assertThrows(UnmatchedUserException.class,
+        () -> recipeService.updateRecipe(request, recipesUpdateDTO));
+
+    // verify
+    verify(recipeRepository, times(1)).findById(1L);
+    verify(ingredientRepository, times(0)).deleteAllByRecipeId(1L);
+    verify(ingredientRepository, times(0)).saveAll(anyList());
+    verify(manualRepository, times(0)).deleteAllByRecipeId(1L);
+    verify(manualRepository, times(0)).saveAll(anyList());
+  }
+
+  @Test
+  @DisplayName("레시피 삭제 성공")
+  void deleteRecipe_Success() {
+    // Given
+    RecipesDeleteDTO deleteDTO = new RecipesDeleteDTO(
+        1L
+    );
+
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(userAccessHandler.findByUserId(1L)).thenReturn(user);
+    when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
+
+    // When
+    ResultResponse result = recipeService.deleteRecipe(request, deleteDTO);
+
+    // Then
+    assertEquals("레시피를 정상적으로 삭제하였습니다.", result.getMessage());
+
+    // verify
+    verify(recipeRepository, times(1)).deleteById(recipe.getId());
+  }
+
+  @Test
+  @DisplayName("레시피 삭제 실패 - 등록한 유저와 삭제하는 유저가 다를 때")
+  void deleteRecipe_FailUnMatchedUser() {
+    // given
+    UserEntity requestUser = UserEntity.builder()
+        .userId(2L)
+        .build();
+    RecipesDeleteDTO deleteDTO = new RecipesDeleteDTO(
+        1L
+    );
+
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(2L);
+    when(userAccessHandler.findByUserId(requestUser.getUserId())).thenReturn(requestUser);
+    when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.ofNullable(recipe));
+
+    // when & then
+    assertThrows(UnmatchedUserException.class,
+        () -> recipeService.deleteRecipe(request, deleteDTO));
+
+    // verify
+    verify(recipeRepository, times(1)).findById(1L);
+    verify(recipeRepository, times(0)).deleteById(recipe.getId());
+  }
+
+  @Test
+  @DisplayName("전체 레시피 목록 조회 성공")
+  void getRecipes_Success() {
+    // given
+    List<RecipeEntity> recipeEntities = List.of(
+        RecipeEntity.builder()
+            .id(1L)
+            .name("Recipe1")
+            .user(user)
+            .level(LevelType.LOW)
+            .time(CookingTimeType.TEN_MINUTES)
+            .thumbnail("thumbnail1")
+            .build(),
+        RecipeEntity.builder()
+            .id(2L)
+            .name("Recipe2")
+            .user(user)
+            .level(LevelType.MEDIUM)
+            .time(CookingTimeType.TWENTY_MINUTES)
+            .thumbnail("thumbnail2")
+            .build()
+    );
+
+    Page<RecipeEntity> recipePage = new PageImpl<>(recipeEntities);
+
+    when(recipeRepository.findAll(any(Pageable.class))).thenReturn(recipePage);
+
+    // when
+    ResultResponse result = recipeService.getRecipes(0, 10);
+
+    // then
+    assertEquals("전체 레시피 조회 성공!", result.getMessage());
+    List<RecipesSummary> summaries = (List<RecipesSummary>) result.getData();
+    assertEquals(2, summaries.size());
+    assertEquals("Recipe1", summaries.get(0).getRecipeName());
+    assertEquals("Recipe2", summaries.get(1).getRecipeName());
+  }
+
+  @Test
+  @DisplayName("전체 레시피 목록 조회 실패 - 레시피 없음")
+  void getRecipes_Fail_NoRecipes() {
+    // given
+    Page<RecipeEntity> emptyPage = Page.empty();
+
+    when(recipeRepository.findAll(any(Pageable.class))).thenReturn(emptyPage);
+
+    // when & then
+    assertThrows(RecipeNotFoundException.class,
+        () -> recipeService.getRecipes(0, 10));
+  }
+
+  @Test
+  @DisplayName("레시피 조건 검색 성공")
+  void searchRecipes_Success() {
+    // given
+    RecipesSearchDTO searchDTO = new RecipesSearchDTO(
+        List.of("돼지고기"),
+        LevelType.LOW,
+        CookingTimeType.TEN_MINUTES
+        );
+    List<RecipeEntity> recipeEntities = List.of(
+        RecipeEntity.builder()
+            .id(1L)
+            .name("Recipe1")
+            .user(user)
+            .level(LevelType.LOW)
+            .time(CookingTimeType.TEN_MINUTES)
+            .thumbnail("thumbnail1")
+            .build()
+    );
+    Page<RecipeEntity> recipePage = new PageImpl<>(recipeEntities);
+
+    when(recipeRepository.searchAndRecipes(any(), any(), any(), anyLong(), any(Pageable.class))).thenReturn(recipePage);
+
+    // when
+    ResultResponse result = recipeService.searchRecipes(searchDTO, 0, 10);
+
+    // then
+    assertEquals("레시피 조회 성공!", result.getMessage());
+    List<RecipesSummary> summaries = (List<RecipesSummary>) result.getData();
+    assertEquals(1, summaries.size());
+    assertEquals("Recipe1", summaries.get(0).getRecipeName());
+  }
+
+  @Test
+  @DisplayName("레시피 조건 검색 실패 - 조건에 맞는 레시피 없음")
+  void searchRecipes_Fail_NoRecipes() {
+    // given
+    RecipesSearchDTO searchDTO = new RecipesSearchDTO(
+        List.of("돼지고기"),
+        LevelType.LOW,
+        CookingTimeType.TEN_MINUTES
+    );
+    Page<RecipeEntity> emptyPage = Page.empty();
+
+    when(recipeRepository.searchAndRecipes(any(), any(), any(), anyLong(), any(Pageable.class))).thenReturn(emptyPage);
+    when(recipeRepository.searchOrRecipes(any(), any(), any(), any(Pageable.class))).thenReturn(emptyPage);
+
+    // when & then
+    assertThrows(RecipeNotFoundException.class,
+        () -> recipeService.searchRecipes(searchDTO, 0, 10));
+  }
+
+  @Test
+  @DisplayName("레시피 상세 조회 성공")
+  void getRecipeDetail_Success() {
+    // given
+    List<CommentEntity> commentEntities = new ArrayList<>();
+    commentEntities.add(CommentEntity.builder()
+        .commentId(1L)
+        .user(user)
+        .recipe(recipe)
+        .commentContent("Great recipe!")
+        .commentLike(5.0)
+        .build());
+
+    recipe = RecipeEntity.builder()
+        .id(1L)
+        .user(user)
+        .name("recipeName")
+        .level(LevelType.LOW)
+        .time(CookingTimeType.FIFTEEN_MINUTES)
+        .thumbnail("thumbnail")
+        .ingredients(ingredients)
+        .manuals(manuals)
+        .comments(commentEntities)
+        .build();
+
+    when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
+
+    // when
+    ResultResponse result = recipeService.getRecipeDetail(recipe.getId());
+
+    // then
+    assertEquals("레시피 상세 조회 성공", result.getMessage());
+    RecipesInfo recipesInfo = (RecipesInfo) result.getData();
+    assertEquals(recipe.getName(), recipesInfo.getRecipeName());
+    assertEquals(recipe.getUser().getNickname(), recipesInfo.getRecipeAuthor());
+    assertFalse(recipesInfo.getIngredients().isEmpty());
+    assertFalse(recipesInfo.getRecipesManuals().getRecipesManuals().isEmpty());
+    assertFalse(recipesInfo.getComments().getComments().isEmpty());
+  }
+
+  @Test
+  @DisplayName("레시피 평점으로 조회 성공")
+  void getRecipesByRating_Success() {
+    // given
+    int page = 0;
+    int size = 10;
+
+    List<RecipeEntity> recipeList = new ArrayList<>();
+    recipeList.add(recipe);
+
+    Pageable pageable = PageRequest.of(page, size);
+    Page<RecipeEntity> recipePage = new PageImpl<>(recipeList);
+
+    when(recipeRepository.findAllOrderByRating(pageable)).thenReturn(recipePage);
+
+    // when
+    ResultResponse result = recipeService.getRecipesByRating(0, 10);
+
+    // then
+    assertEquals("인기 레시피 조회 성공", result.getMessage());
+    assertNotNull(result.getData());
+    List<RecipesSummary> recipesSummaries = (List<RecipesSummary>) result.getData();
+    assertEquals(1, recipesSummaries.size());
+    assertEquals(recipe.getId(), recipesSummaries.get(0).getRecipeId());
+    assertEquals(recipe.getName(), recipesSummaries.get(0).getRecipeName());
+    assertEquals(recipe.getUser().getNickname(), recipesSummaries.get(0).getRecipeAuthor());
+  }
+
+  @Test
+  @DisplayName("레시피 평점으로 조회 실패 (레시피 없음)")
+  void getRecipesByRating_FailNotFoundRecipe() {
+    // given
+    int page = 0;
+    int size = 10;
+
+    Pageable pageable = PageRequest.of(page, size);
+    Page<RecipeEntity> emptyPage = new PageImpl<>(new ArrayList<>(), pageable, 0);
+
+    when(recipeRepository.findAllOrderByRating(pageable)).thenReturn(emptyPage);
+
+    // when & Then
+    assertThrows(RecipeNotFoundException.class,
+        () -> recipeService.getRecipesByRating(page, size));
+  }
+
+  @Test
+  @DisplayName("레시피 스크랩 성공")
+  void scrapedRecipe_Success() {
+    // given
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
+    when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
+
+    // when
+    ResultResponse result = recipeService.scrapedRecipe(request, recipe.getId());
+
+    // then
+    assertEquals("레시피 찜하기 성공", result.getMessage());
+
+    // verify
+    verify(scrapedRecipeRepository, times(1)).save(any());
+  }
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 레시피 등록 API
- 레시피 수정 API
  - 재료와 메뉴얼은 가짓수가 변경(늘어나거나 줄어들거나)될 수 있어서 기존 내용 삭제 후 삽입 형태로 구현
- 레시피 삭제 API
- 레시피 조회 API (조회 관련 API는 모두 페이징 처리)
  - 전체 조회 (모든 레시피 조회)
  - 조건(재료명, 난이도, 요리시간) 조회
    - 조회 관련 쿼리 작성
  - 인기순 조회
    - Rating 으로 내림차순 정렬 후 조회
- 레시피 스크랩 API
- 레시피 상세 페이지 API

- 현재 모든 이미지 관련 부분들은 String으로 구현되어 있음.
  - 추후 S3 도입 후에 수정될 예정

- 테이블에 레시피 중복 저장 되는 부분 삭제

## 스크린샷
- Service 부분 테스트 진행 결과
<img width="1040" alt="스크린샷 2024-10-10 오후 6 47 53" src="https://github.com/user-attachments/assets/def8b966-6dc6-4ab7-88ef-df387c4956e5">
## 주의사항

Closes #44 
