### PR TITLE
[refactor] Jwt 토큰 헤더 명 변경 및 로그인 성공시 닉네임 추가 반환

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -43,11 +43,11 @@ public class JwtFilter extends OncePerRequestFilter {
       return;
     }
 
-    String authorizationHeader = request.getHeader("access-token");
+    String authorizationHeader = request.getHeader("Access-Token");
 
     // Bearer 토큰이 헤더에 있는지 확인
     if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-      logger.info("Access-token is null or doesn't start with Bearer");
+      logger.info("Access-Token is null or doesn't start with Bearer");
       filterChain.doFilter(request, response);
       return;
     }
@@ -68,7 +68,7 @@ public class JwtFilter extends OncePerRequestFilter {
   }
 
   private void setAuthenticationFromToken(HttpServletResponse response, String token) {
-    response.addHeader("access-token", "Bearer " + token);
+    response.addHeader("Access-Token", "Bearer " + token);
 
     Authentication authToken = getAuthToken(token);
     SecurityContextHolder.getContext().setAuthentication(authToken);
@@ -99,7 +99,7 @@ public class JwtFilter extends OncePerRequestFilter {
   // refresh 토큰 반환
   private String getRefreshTokenFromCookies(HttpServletRequest request) {
     return Arrays.stream(request.getCookies())
-        .filter(cookie -> "refresh-token".equals(cookie.getName()))
+        .filter(cookie -> "Refresh-Token".equals(cookie.getName()))
         .map(Cookie::getValue)
         .findFirst()
         .orElse(null);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -36,7 +36,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
 
-    response.addHeader("access-token", "Bearer " + access);
+    response.addHeader("Access-Token", "Bearer " + access);
     response.addCookie(createCookie(refresh));
 
     log.info("OAuth 로그인 성공");
@@ -53,7 +53,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   }
 
   private Cookie createCookie(String value) {
-    Cookie cookie = new Cookie("refresh-token", value);
+    Cookie cookie = new Cookie("Refresh-Token", value);
     cookie.setMaxAge(24 * 60 * 60);
     cookie.setHttpOnly(true);
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SwaggerConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SwaggerConfig.java
@@ -20,7 +20,7 @@ public class SwaggerConfig {
         .components(new Components()
             .addSecuritySchemes("bearerAuth",
                 new SecurityScheme()
-                    .name("access-token")
+                    .name("Access-Token")
                     .type(Type.APIKEY)
                     .in(SecurityScheme.In.HEADER)
                     .bearerFormat("JWT")))

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/WebMvcConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/WebMvcConfig.java
@@ -22,6 +22,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
         .allowedMethods(ALLOW_METHOD_NAMES.split(","))  // 허용할 HTTP Method 목록
         .allowedHeaders("*")        // 모든 HTTP header 허용
         .allowCredentials(true)     // 자격 증명 허용
-        .exposedHeaders("access-token", HttpHeaders.LOCATION);   // 클라이언트에 노출할 헤더 목록
+        .exposedHeaders("Access-Token", HttpHeaders.LOCATION);   // 클라이언트에 노출할 헤더 목록
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
@@ -43,7 +43,7 @@ public class UserController {
   public ResponseEntity<ResultResponse> login(@Valid @RequestBody LoginDTO loginDTO,
       HttpServletResponse response) {
 
-    return ResponseEntity.ok(ResultResponse.of(userService.login(loginDTO, response)));
+    return ResponseEntity.ok(userService.login(loginDTO, response));
   }
 
   // OAuth signup & login from Kakao

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/UserService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/UserService.java
@@ -19,6 +19,6 @@ public interface UserService {
 
   ResultResponse getUserInfo(HttpServletRequest request);
 
-  ResultCode login(LoginDTO loginDTO, HttpServletResponse response);
+  ResultResponse login(LoginDTO loginDTO, HttpServletResponse response);
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/CommentsServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/CommentsServiceImpl.java
@@ -46,7 +46,7 @@ public class CommentsServiceImpl implements CommentsService {
   public ResultResponse writeComment(HttpServletRequest request, CommentsDTO commentsDTO) {
 
     // Token 검사
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
 
     // 유저 존재 검사
     UserEntity user = userAccessHandler.findByUserId(userId);
@@ -79,7 +79,7 @@ public class CommentsServiceImpl implements CommentsService {
   public ResultResponse updateComment(HttpServletRequest request, CommentsUpdateDTO commentsUpdateDTO) {
 
     // Token 검사
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
 
     // 유저 존재 검사
     UserEntity user = userAccessHandler.findByUserId(userId);
@@ -105,7 +105,7 @@ public class CommentsServiceImpl implements CommentsService {
   public ResultResponse deleteComment(HttpServletRequest request, CommentsDeleteDTO commentsDeleteDTO) {
 
     // Token 검사
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
 
     // 유저 존재 검사
     UserEntity user = userAccessHandler.findByUserId(userId);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -55,7 +55,7 @@ public class RecipeServiceImpl implements RecipeService {
   @Override
   @Transactional
   public ResultResponse registerRecipe(HttpServletRequest request, RecipesDTO recipesDTO) {
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 
@@ -103,7 +103,7 @@ public class RecipeServiceImpl implements RecipeService {
   @Transactional
   public ResultResponse updateRecipe(HttpServletRequest request,
       RecipesUpdateDTO recipesUpdateDTO) {
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 
@@ -164,7 +164,7 @@ public class RecipeServiceImpl implements RecipeService {
   @Transactional
   public ResultResponse deleteRecipe(HttpServletRequest request,
       RecipesDeleteDTO recipesDeleteDTO) {
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 
@@ -312,7 +312,7 @@ public class RecipeServiceImpl implements RecipeService {
 
   @Override
   public ResultResponse scrapedRecipe(HttpServletRequest request, Long recipeId) {
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -49,7 +49,7 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public ResultCode login(LoginDTO loginDTO, HttpServletResponse response) {
+  public ResultResponse login(LoginDTO loginDTO, HttpServletResponse response) {
     UserEntity user = userAccessHandler.findByEmail(loginDTO.getEmail());
     userAccessHandler.validatePassword(user.getPassword(), loginDTO.getPassword());
 
@@ -59,7 +59,7 @@ public class UserServiceImpl implements UserService {
     response.addHeader("Access-Token", "Bearer " + access);
     response.addCookie(createCookie(refresh));
 
-    return ResultCode.SUCCESS_LOGIN;
+    return new ResultResponse(ResultCode.SUCCESS_LOGIN, user.getNickname());
   }
 
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -56,7 +56,7 @@ public class UserServiceImpl implements UserService {
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
 
-    response.addHeader("access-token", "Bearer " + access);
+    response.addHeader("Access-Token", "Bearer " + access);
     response.addCookie(createCookie(refresh));
 
     return ResultCode.SUCCESS_LOGIN;
@@ -66,7 +66,7 @@ public class UserServiceImpl implements UserService {
   @Override
   public ResultCode updateUserInfo(HttpServletRequest request, UserUpdateDTO userUpdateDTO) {
     UserEntity user = userAccessHandler
-        .findByUserId(jwtUtil.getUserId(request.getHeader("access-token")));
+        .findByUserId(jwtUtil.getUserId(request.getHeader("Access-Token")));
 
     // 비밀번호 중복 체크
     userAccessHandler.validatePassword(user.getPassword(), userUpdateDTO.getBeforePassword());
@@ -92,7 +92,7 @@ public class UserServiceImpl implements UserService {
   @Override
   public ResultCode deleteUser(HttpServletRequest request, DeleteUserDTO deleteUserDTO) {
     UserEntity user = userAccessHandler
-        .findByUserId(jwtUtil.getUserId(request.getHeader("access-token")));
+        .findByUserId(jwtUtil.getUserId(request.getHeader("Access-Token")));
 
     if (user.getProvider() == null) {
       userAccessHandler.validatePassword(user.getPassword(), deleteUserDTO.getPassword());
@@ -106,7 +106,7 @@ public class UserServiceImpl implements UserService {
   @Override
   public ResultResponse getUserInfo(HttpServletRequest request) {
     UserEntity user = userAccessHandler
-        .findByUserId(jwtUtil.getUserId(request.getHeader("access-token")));
+        .findByUserId(jwtUtil.getUserId(request.getHeader("Access-Token")));
 
     return new ResultResponse(SUCCESS_GET_USER_INFO,
         new UserInfoDTO(user.getEmail(), user.getNickname()));
@@ -114,7 +114,7 @@ public class UserServiceImpl implements UserService {
 
 
   private Cookie createCookie(String value) {
-    Cookie cookie = new Cookie("refresh-token", value);
+    Cookie cookie = new Cookie("Refresh-Token", value);
     cookie.setMaxAge(24 * 60 * 60);
     cookie.setHttpOnly(true);
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandlerTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/auth/oauth2/handler/OAuth2SuccessHandlerTest.java
@@ -109,7 +109,7 @@ class OAuth2SuccessHandlerTest {
     oAuth2SuccessHandler.onAuthenticationSuccess(request, response, authentication);
 
     // then
-    verify(response).addHeader("access-token", "Bearer " + ACCESS_TOKEN);
+    verify(response).addHeader("Access-Token", "Bearer " + ACCESS_TOKEN);
     verify(response).addCookie(any(Cookie.class));
     verify(redirectStrategy).sendRedirect(eq(request), eq(response), anyString());
   }

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
@@ -82,7 +82,7 @@ class CommentsServiceImplTest {
     CommentsDTO requestDTO = new CommentsDTO(recipeId, "댓글 내용", 5.0);
 
     // when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(recipeRepository.findById(recipeId)).thenReturn(Optional.of(recipe));
 
@@ -118,7 +118,7 @@ class CommentsServiceImplTest {
     CommentsDTO requestDTO = new CommentsDTO(recipeId, "댓글 내용", 5.0);
 
     // when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(recipeRepository.findById(recipeId)).thenReturn(Optional.of(recipe));
 
@@ -155,7 +155,7 @@ class CommentsServiceImplTest {
     CommentsUpdateDTO requestDTO = new CommentsUpdateDTO(commentId, "새로운 댓글 내용", 4.0);
 
     // when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(oldComment));
 
@@ -205,7 +205,7 @@ class CommentsServiceImplTest {
     CommentsUpdateDTO requestDTO = new CommentsUpdateDTO(commentId, "새로운 댓글 내용", 4.0);
 
     //when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(requestUserId);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(requestUserId);
     when(userAccessHandler.findByUserId(requestUserId)).thenReturn(requestUser);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(oldComment));
 
@@ -237,7 +237,7 @@ class CommentsServiceImplTest {
 
     CommentsDeleteDTO requestDTO = new CommentsDeleteDTO(commentId);
     // when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
 
@@ -276,7 +276,7 @@ class CommentsServiceImplTest {
 
     CommentsDeleteDTO requestDTO = new CommentsDeleteDTO(commentId);
     // when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(requestUserId);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(requestUserId);
     when(userAccessHandler.findByUserId(requestUserId)).thenReturn(requestUser);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -165,7 +165,7 @@ class RecipeServiceImplTest {
   @DisplayName("레시피 등록 성공")
   void registerRecipe_Success() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
 
     // when
@@ -195,7 +195,7 @@ class RecipeServiceImplTest {
         .manuals(manualEntities)
         .build();
 
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(1L)).thenReturn(user);
     when(recipeRepository.findById(1L)).thenReturn(Optional.of(recipe));
     when(ingredientRepository.findAllByRecipeId(1L)).thenReturn(Optional.of(ingredientEntities));
@@ -223,7 +223,7 @@ class RecipeServiceImplTest {
         .userId(2L)
         .build();
 
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(2L);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(2L);
     when(userAccessHandler.findByUserId(requestUser.getUserId())).thenReturn(requestUser);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.ofNullable(recipe));
 
@@ -247,7 +247,7 @@ class RecipeServiceImplTest {
         1L
     );
 
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(1L)).thenReturn(user);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
 
@@ -272,7 +272,7 @@ class RecipeServiceImplTest {
         1L
     );
 
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(2L);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(2L);
     when(userAccessHandler.findByUserId(requestUser.getUserId())).thenReturn(requestUser);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.ofNullable(recipe));
 
@@ -480,7 +480,7 @@ class RecipeServiceImplTest {
   @DisplayName("레시피 스크랩 성공")
   void scrapedRecipe_Success() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -61,8 +61,8 @@ class UserServiceImplTest {
   private static final String BEFORE_PASSWORD = "oldPassword";
   private static final String AFTER_PASSWORD = "newPassword";
   private static final String NEW_NICKNAME = "newNickName";
-  private static final String ACCESS = "access-token";
-  private static final String REFRESH = "refresh-token";
+  private static final String ACCESS = "Access-Token";
+  private static final String REFRESH = "Refresh-Token";
 
   private SignupDTO signup;
   private UserUpdateDTO userUpdateDTO;
@@ -170,7 +170,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 성공 - 닉네임, 패스워드 모두 변경")
   void updateUserInfo_SuccessForPasswordAndNickname() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -190,7 +190,7 @@ class UserServiceImplTest {
     // given
     UserUpdateDTO userUpdateDTO = new UserUpdateDTO("nickname", BEFORE_PASSWORD, AFTER_PASSWORD);
 
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -206,7 +206,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 존재하지 않은 회원인 경우")
   void updateUserInfo_NotFoundUser() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
 
     // when then
@@ -218,7 +218,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 비밀번호가 일치하지 않은 경우")
   void updateUserInfo_PasswordMisMatch() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doThrow(new PasswordMismatchException()).when(userAccessHandler)
@@ -233,7 +233,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 카카오로 로그인을 한 회원")
   void updateUserInfo_SocialAccountException() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(kakaoUser);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -249,7 +249,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 닉네임이 중복인 경우")
   void updateUserInfo_DuplicationNickname() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -268,7 +268,7 @@ class UserServiceImplTest {
   void deleteUser_Success() {
 
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
     doNothing().when(userAccessHandler)
         .validatePassword(user.getPassword(), deleteUserDTO.getPassword());
@@ -285,7 +285,7 @@ class UserServiceImplTest {
   void deleteUser_Success_SocialAccount() {
 
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(kakaoUser);
 
     // when
@@ -299,7 +299,7 @@ class UserServiceImplTest {
   @DisplayName("회원 탈퇴 실패 : 존재하지 않은 회원인 경우")
   void deleteUser_NotFoundUser() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
 
     // when then
@@ -312,7 +312,7 @@ class UserServiceImplTest {
   void deleteUser_PasswordMisMatch() {
 
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doThrow(new PasswordMismatchException()).when(userAccessHandler)
@@ -327,7 +327,7 @@ class UserServiceImplTest {
   @DisplayName("회원 정보 조회 성공")
   void getUserInfo_Success() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     // when
@@ -343,7 +343,7 @@ class UserServiceImplTest {
   @DisplayName("회원 정보 조회 실패 : 존재하지 않은 사용자")
   void getUserInfo_NotFoundUser() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
 
     // when then

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
@@ -135,9 +136,10 @@ class UserServiceImplTest {
     when(jwtUtil.createJwt("refresh", user.getUserId(), user.getRole())).thenReturn(REFRESH);
 
     // when
-    ResultCode resultCode = userServiceimpl.login(loginDTO, response);
+    ResultResponse resultResponse = userServiceimpl.login(loginDTO, response);
 
-    assertEquals(ResultCode.SUCCESS_LOGIN, resultCode);
+    assertEquals(resultResponse.getCode(), HttpStatus.OK);
+    assertEquals(resultResponse.getData(), user.getNickname());
   }
 
   @Test


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
Jwt 토큰 헤더 명 변경 및 로그인 성공시 닉네임 추가 반환 할 수 있도록 수정하였습니다.

- access-token -> Access-Token
- refresh-token -> Refresh-token
- 로그인 성공시  ResultResponse data값에 닉네임 추가

## 스크린샷

## 주의사항

Closes #74 
