### PR TITLE
[refactor] Http Header key값 변경 

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -41,11 +41,11 @@ public class JwtFilter extends OncePerRequestFilter {
       return;
     }
 
-    String authorizationHeader = request.getHeader("Access-Token");
+    String authorizationHeader = request.getHeader("access-token");
 
     // Bearer 토큰이 헤더에 있는지 확인
     if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-      logger.info("Access-Token is null or doesn't start with Bearer");
+      logger.info("access-token is null or doesn't start with Bearer");
       filterChain.doFilter(request, response);
       return;
     }
@@ -66,7 +66,7 @@ public class JwtFilter extends OncePerRequestFilter {
   }
 
   private void setAuthenticationFromToken(HttpServletResponse response, String token) {
-    response.addHeader("Access-Token", "Bearer " + token);
+    response.addHeader("access-token", "Bearer " + token);
 
     Authentication authToken = getAuthToken(token);
     SecurityContextHolder.getContext().setAuthentication(authToken);
@@ -76,7 +76,7 @@ public class JwtFilter extends OncePerRequestFilter {
   // access 토큰이 만료되었을 경우 refresh 토큰 검증 후 재 발급
   private void expiredAccessToken(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
-    logger.info("Access-Token is Expired!!");
+    logger.info("access-token is Expired!!");
     String refreshToken = getRefreshTokenFromCookies(request);
 
     if (refreshToken == null) {
@@ -97,7 +97,7 @@ public class JwtFilter extends OncePerRequestFilter {
   // refresh 토큰 반환
   private String getRefreshTokenFromCookies(HttpServletRequest request) {
     return Arrays.stream(request.getCookies())
-        .filter(cookie -> "Refresh-Token".equals(cookie.getName()))
+        .filter(cookie -> "refresh-token".equals(cookie.getName()))
         .map(Cookie::getValue)
         .findFirst()
         .orElse(null);
@@ -113,7 +113,7 @@ public class JwtFilter extends OncePerRequestFilter {
   // access 토큰 재발급
   private String createNewAccessToken(String refreshToken) {
 
-    logger.info("Create New Access-Token!");
+    logger.info("Create New access-token!");
 
     Long userId = jwtUtil.getUserId(refreshToken);
     UserRole role = UserRole.valueOf(jwtUtil.getRole(refreshToken));

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/CustomOauth2UserService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/oauth2/CustomOauth2UserService.java
@@ -55,7 +55,7 @@ public class CustomOauth2UserService  {
         Map.class
     );
 
-    // Access-token 반환
+    // access-token 반환
     if (response.getStatusCode() == HttpStatus.OK) {
       Map responseBody = response.getBody();
       if (responseBody != null && responseBody.containsKey("access_token")) {

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SwaggerConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SwaggerConfig.java
@@ -20,7 +20,7 @@ public class SwaggerConfig {
         .components(new Components()
             .addSecuritySchemes("bearerAuth",
                 new SecurityScheme()
-                    .name("Access-Token")
+                    .name("access-token")
                     .type(Type.APIKEY)
                     .in(SecurityScheme.In.HEADER)
                     .bearerFormat("JWT")))

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/WebMvcConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/WebMvcConfig.java
@@ -22,6 +22,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
         .allowedMethods(ALLOW_METHOD_NAMES.split(","))  // 허용할 HTTP Method 목록
         .allowedHeaders("*")        // 모든 HTTP header 허용
         .allowCredentials(true)     // 자격 증명 허용
-        .exposedHeaders("Access-Token", HttpHeaders.LOCATION);   // 클라이언트에 노출할 헤더 목록
+        .exposedHeaders("access-token", HttpHeaders.LOCATION);   // 클라이언트에 노출할 헤더 목록
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/CommentsServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/CommentsServiceImpl.java
@@ -46,7 +46,7 @@ public class CommentsServiceImpl implements CommentsService {
   public ResultResponse writeComment(HttpServletRequest request, CommentsDTO commentsDTO) {
 
     // Token 검사
-    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
 
     // 유저 존재 검사
     UserEntity user = userAccessHandler.findByUserId(userId);
@@ -79,7 +79,7 @@ public class CommentsServiceImpl implements CommentsService {
   public ResultResponse updateComment(HttpServletRequest request, CommentsUpdateDTO commentsUpdateDTO) {
 
     // Token 검사
-    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
 
     // 유저 존재 검사
     UserEntity user = userAccessHandler.findByUserId(userId);
@@ -105,7 +105,7 @@ public class CommentsServiceImpl implements CommentsService {
   public ResultResponse deleteComment(HttpServletRequest request, CommentsDeleteDTO commentsDeleteDTO) {
 
     // Token 검사
-    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
 
     // 유저 존재 검사
     UserEntity user = userAccessHandler.findByUserId(userId);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -53,7 +53,7 @@ public class RecipeServiceImpl implements RecipeService {
   @Override
   @Transactional
   public ResultResponse registerRecipe(HttpServletRequest request, RecipesDTO recipesDTO) {
-    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 
@@ -101,7 +101,7 @@ public class RecipeServiceImpl implements RecipeService {
   @Transactional
   public ResultResponse updateRecipe(HttpServletRequest request,
       RecipesUpdateDTO recipesUpdateDTO) {
-    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 
@@ -162,7 +162,7 @@ public class RecipeServiceImpl implements RecipeService {
   @Transactional
   public ResultResponse deleteRecipe(HttpServletRequest request,
       RecipesDeleteDTO recipesDeleteDTO) {
-    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 
@@ -306,7 +306,7 @@ public class RecipeServiceImpl implements RecipeService {
 
   @Override
   public ResultResponse scrapedRecipe(HttpServletRequest request, Long recipeId) {
-    Long userId = jwtUtil.getUserId(request.getHeader("Access-Token"));
+    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -63,7 +63,7 @@ public class UserServiceImpl implements UserService {
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
 
-    response.addHeader("Access-Token", "Bearer " + access);
+    response.addHeader("access-token", "Bearer " + access);
     response.addCookie(createCookie(refresh));
 
     return new ResultResponse(ResultCode.SUCCESS_LOGIN, user.getNickname());
@@ -85,7 +85,7 @@ public class UserServiceImpl implements UserService {
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
 
-    response.addHeader("Access-Token", "Bearer " + access);
+    response.addHeader("access-token", "Bearer " + access);
     response.addCookie(createCookie(refresh));
 
     return new ResultResponse(ResultCode.SUCCESS_LOGIN, user.getNickname());
@@ -96,7 +96,7 @@ public class UserServiceImpl implements UserService {
   public ResultCode updateUserInfo(HttpServletRequest request, UserUpdateDTO userUpdateDTO) {
 
     UserEntity user = userAccessHandler
-        .findByUserId(jwtUtil.getUserId(request.getHeader("Access-Token")));
+        .findByUserId(jwtUtil.getUserId(request.getHeader("access-token")));
 
     // 비밀번호 중복 체크
     userAccessHandler.validatePassword(user.getPassword(), userUpdateDTO.getBeforePassword());
@@ -126,7 +126,7 @@ public class UserServiceImpl implements UserService {
   public ResultCode deleteUser(HttpServletRequest request, DeleteUserDTO deleteUserDTO) {
 
     UserEntity user = userAccessHandler
-        .findByUserId(jwtUtil.getUserId(request.getHeader("Access-Token")));
+        .findByUserId(jwtUtil.getUserId(request.getHeader("access-token")));
 
     if (user.getProvider() == null) {
       userAccessHandler.validatePassword(user.getPassword(), deleteUserDTO.getPassword());
@@ -141,7 +141,7 @@ public class UserServiceImpl implements UserService {
   public ResultResponse getUserInfo(HttpServletRequest request) {
 
     UserEntity user = userAccessHandler
-        .findByUserId(jwtUtil.getUserId(request.getHeader("Access-Token")));
+        .findByUserId(jwtUtil.getUserId(request.getHeader("access-token")));
 
     return new ResultResponse(SUCCESS_GET_USER_INFO,
         new UserInfoDTO(user.getEmail(), user.getNickname()));
@@ -149,7 +149,7 @@ public class UserServiceImpl implements UserService {
 
 
   private Cookie createCookie(String value) {
-    Cookie cookie = new Cookie("Refresh-Token", value);
+    Cookie cookie = new Cookie("refresh-token", value);
     cookie.setMaxAge(24 * 60 * 60);
     cookie.setHttpOnly(true);
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
@@ -82,7 +82,7 @@ class CommentsServiceImplTest {
     CommentsDTO requestDTO = new CommentsDTO(recipeId, "댓글 내용", 5.0);
 
     // when
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(recipeRepository.findById(recipeId)).thenReturn(Optional.of(recipe));
 
@@ -118,7 +118,7 @@ class CommentsServiceImplTest {
     CommentsDTO requestDTO = new CommentsDTO(recipeId, "댓글 내용", 5.0);
 
     // when
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(recipeRepository.findById(recipeId)).thenReturn(Optional.of(recipe));
 
@@ -155,7 +155,7 @@ class CommentsServiceImplTest {
     CommentsUpdateDTO requestDTO = new CommentsUpdateDTO(commentId, "새로운 댓글 내용", 4.0);
 
     // when
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(oldComment));
 
@@ -205,7 +205,7 @@ class CommentsServiceImplTest {
     CommentsUpdateDTO requestDTO = new CommentsUpdateDTO(commentId, "새로운 댓글 내용", 4.0);
 
     //when
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(requestUserId);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(requestUserId);
     when(userAccessHandler.findByUserId(requestUserId)).thenReturn(requestUser);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(oldComment));
 
@@ -237,7 +237,7 @@ class CommentsServiceImplTest {
 
     CommentsDeleteDTO requestDTO = new CommentsDeleteDTO(commentId);
     // when
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
 
@@ -276,7 +276,7 @@ class CommentsServiceImplTest {
 
     CommentsDeleteDTO requestDTO = new CommentsDeleteDTO(commentId);
     // when
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(requestUserId);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(requestUserId);
     when(userAccessHandler.findByUserId(requestUserId)).thenReturn(requestUser);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -165,7 +165,7 @@ class RecipeServiceImplTest {
   @DisplayName("레시피 등록 성공")
   void registerRecipe_Success() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
 
     // when
@@ -195,7 +195,7 @@ class RecipeServiceImplTest {
         .manuals(manualEntities)
         .build();
 
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(1L)).thenReturn(user);
     when(recipeRepository.findById(1L)).thenReturn(Optional.of(recipe));
     when(ingredientRepository.findAllByRecipeId(1L)).thenReturn(Optional.of(ingredientEntities));
@@ -223,7 +223,7 @@ class RecipeServiceImplTest {
         .userId(2L)
         .build();
 
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(2L);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(2L);
     when(userAccessHandler.findByUserId(requestUser.getUserId())).thenReturn(requestUser);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.ofNullable(recipe));
 
@@ -247,7 +247,7 @@ class RecipeServiceImplTest {
         1L
     );
 
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(1L)).thenReturn(user);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
 
@@ -272,7 +272,7 @@ class RecipeServiceImplTest {
         1L
     );
 
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(2L);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(2L);
     when(userAccessHandler.findByUserId(requestUser.getUserId())).thenReturn(requestUser);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.ofNullable(recipe));
 
@@ -480,7 +480,7 @@ class RecipeServiceImplTest {
   @DisplayName("레시피 스크랩 성공")
   void scrapedRecipe_Success() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -70,8 +70,8 @@ class UserServiceImplTest {
   private static final String BEFORE_PASSWORD = "oldPassword";
   private static final String AFTER_PASSWORD = "newPassword";
   private static final String NEW_NICKNAME = "newNickName";
-  private static final String ACCESS = "Access-Token";
-  private static final String REFRESH = "Refresh-Token";
+  private static final String ACCESS = "access-token";
+  private static final String REFRESH = "refresh-token";
   private static final String CODE = "kakaoCode";
   private static final String KAKAO_ACCESS_TOKEN = "kakaoAccessToken";
 
@@ -237,7 +237,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 성공 - 닉네임, 패스워드 모두 변경")
   void updateUserInfo_SuccessForPasswordAndNickname() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -257,7 +257,7 @@ class UserServiceImplTest {
     // given
     UserUpdateDTO userUpdateDTO = new UserUpdateDTO("nickname", BEFORE_PASSWORD, AFTER_PASSWORD);
 
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -273,7 +273,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 존재하지 않은 회원인 경우")
   void updateUserInfo_NotFoundUser() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
 
     // when then
@@ -285,7 +285,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 비밀번호가 일치하지 않은 경우")
   void updateUserInfo_PasswordMisMatch() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doThrow(new PasswordMismatchException()).when(userAccessHandler)
@@ -300,7 +300,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 카카오로 로그인을 한 회원")
   void updateUserInfo_SocialAccountException() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(kakaoUser);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -316,7 +316,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 닉네임이 중복인 경우")
   void updateUserInfo_DuplicationNickname() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -335,7 +335,7 @@ class UserServiceImplTest {
   void deleteUser_Success() {
 
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
     doNothing().when(userAccessHandler)
         .validatePassword(user.getPassword(), deleteUserDTO.getPassword());
@@ -352,7 +352,7 @@ class UserServiceImplTest {
   void deleteUser_Success_SocialAccount() {
 
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(kakaoUser);
 
     // when
@@ -366,7 +366,7 @@ class UserServiceImplTest {
   @DisplayName("회원 탈퇴 실패 : 존재하지 않은 회원인 경우")
   void deleteUser_NotFoundUser() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
 
     // when then
@@ -379,7 +379,7 @@ class UserServiceImplTest {
   void deleteUser_PasswordMisMatch() {
 
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doThrow(new PasswordMismatchException()).when(userAccessHandler)
@@ -394,7 +394,7 @@ class UserServiceImplTest {
   @DisplayName("회원 정보 조회 성공")
   void getUserInfo_Success() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     // when
@@ -410,7 +410,7 @@ class UserServiceImplTest {
   @DisplayName("회원 정보 조회 실패 : 존재하지 않은 사용자")
   void getUserInfo_NotFoundUser() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("Access-Token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
 
     // when then


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 서버 측에서는 Http Header의 key값을 대문자로 설정 후 클라이언트측에 전달을 했지만, 클라이언트 측은 소문자로 전달을 받는 문제가 발생 되었습니다.

- 문제 원인 
   - SSl 등록 후 Http -> Http/2 프로토콜로 변경이 되면서 Header의 Key이 소문자로 변경 
   - Http/2 프로토콜은 대소문자를 구분하지는 않지만 인코딩전 소문자로 변경을 해야 한다.

- 수정한 내용
   - 클라이언트 측에 전달하는 Header Key값을 소문자로 변경
      - Access-Token -> access-token
      - Refresh-Token -> refresh-token  

## 스크린샷

## 주의사항

Closes #83 
