### PR TITLE
[fix] 카카오 로그인 성공시, 결과 값을 반환할 경로 수정

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/UserController.java
@@ -9,9 +9,12 @@ import com.recipe.jamanchu.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -48,10 +51,14 @@ public class UserController {
 
   // OAuth signup & login from Kakao
   @GetMapping("/login/auth/kakao")
-  public ResponseEntity<ResultResponse> kakaoLogin(@RequestParam String code,
+  public ResponseEntity<Void> kakaoLogin(@RequestParam String code,
       HttpServletResponse response) {
 
-    return ResponseEntity.ok().body(userService.kakaoLogin(code, response));
+    String redirectUrl = userService.kakaoLogin(code, response);
+    HttpHeaders headers = new HttpHeaders();
+    headers.setLocation(URI.create(redirectUrl));
+
+    return ResponseEntity.status(HttpStatus.FOUND).headers(headers).build();
   }
 
   // 회원 정보 수정

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/UserService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/UserService.java
@@ -21,6 +21,6 @@ public interface UserService {
 
   ResultResponse login(LoginDTO loginDTO, HttpServletResponse response);
 
-  ResultResponse kakaoLogin(String code, HttpServletResponse response);
+  String kakaoLogin(String code, HttpServletResponse response);
 }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Service
@@ -71,7 +72,7 @@ public class UserServiceImpl implements UserService {
 
   // 카카오 로그인
   @Override
-  public ResultResponse kakaoLogin(String code, HttpServletResponse response) {
+  public String kakaoLogin(String code, HttpServletResponse response) {
 
     // "인가 코드"로 "액세스 토큰" 요청
     String accessToken = oauth2UserService.getAccessToken(code);
@@ -85,10 +86,13 @@ public class UserServiceImpl implements UserService {
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
 
-    response.addHeader("access-token", "Bearer " + access);
     response.addCookie(createCookie(refresh));
 
-    return new ResultResponse(ResultCode.SUCCESS_LOGIN, user.getNickname());
+    return UriComponentsBuilder.fromUriString("https://frontend-dun-eight-78.vercel.app/users/login/auth/kakao")
+        .queryParam("access-token", access)
+        .queryParam("nickname", user.getNickname())
+        .build()
+        .toUriString();
   }
 
   // 회원 정보 수정

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -34,6 +34,7 @@ public class UserServiceImpl implements UserService {
   private final UserAccessHandler userAccessHandler;
   private final JwtUtil jwtUtil;
   private final CustomOauth2UserService oauth2UserService;
+  private final String REDIRECT_URI = "https://frontend-dun-eight-78.vercel.app/users/login/auth/kakao";
 
   // 회원가입
   @Override
@@ -88,7 +89,7 @@ public class UserServiceImpl implements UserService {
 
     response.addCookie(createCookie(refresh));
 
-    return UriComponentsBuilder.fromUriString("https://frontend-dun-eight-78.vercel.app/users/login/auth/kakao")
+    return UriComponentsBuilder.fromUriString(REDIRECT_URI)
         .queryParam("access-token", access)
         .queryParam("nickname", user.getNickname())
         .build()
@@ -156,6 +157,7 @@ public class UserServiceImpl implements UserService {
     Cookie cookie = new Cookie("refresh-token", value);
     cookie.setMaxAge(24 * 60 * 60);
     cookie.setHttpOnly(true);
+    cookie.setSecure(true);
 
     return cookie;
   }

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -75,6 +75,7 @@ class UserServiceImplTest {
   private static final String REFRESH = "refresh-token";
   private static final String CODE = "kakaoCode";
   private static final String KAKAO_ACCESS_TOKEN = "kakaoAccessToken";
+  private final String REDIRECT_URI = "https://frontend-dun-eight-78.vercel.app/users/login/auth/kakao";
 
   private SignupDTO signup;
   private UserUpdateDTO userUpdateDTO;
@@ -84,6 +85,7 @@ class UserServiceImplTest {
   private UserInfoDTO userInfoDTO;
   private LoginDTO loginDTO;
   private KakaoUserDetails kakaoUserDetails;
+
 
   @BeforeEach
   void setUp() {
@@ -207,7 +209,7 @@ class UserServiceImplTest {
     String resultResponse = userServiceimpl.kakaoLogin(CODE, response);
 
     // then
-    String response = UriComponentsBuilder.fromUriString("https://frontend-dun-eight-78.vercel.app/users/login/auth/kakao")
+    String response = UriComponentsBuilder.fromUriString(REDIRECT_URI)
         .queryParam("access-token", ACCESS)
         .queryParam("nickname", user.getNickname())
         .build()

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -37,6 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
@@ -203,13 +204,16 @@ class UserServiceImplTest {
     when(jwtUtil.createJwt("refresh", user.getUserId(), user.getRole())).thenReturn(REFRESH);
 
     // when
-    ResultResponse resultResponse = userServiceimpl.kakaoLogin(CODE, response);
+    String resultResponse = userServiceimpl.kakaoLogin(CODE, response);
 
     // then
-    ResultResponse response = new ResultResponse(ResultCode.SUCCESS_LOGIN, NICKNAME);
-    assertEquals(response.getCode(), resultResponse.getCode());
-    assertEquals(response.getMessage(), resultResponse.getMessage());
-    assertEquals(response.getData(), resultResponse.getData());
+    String response = UriComponentsBuilder.fromUriString("https://frontend-dun-eight-78.vercel.app/users/login/auth/kakao")
+        .queryParam("access-token", ACCESS)
+        .queryParam("nickname", user.getNickname())
+        .build()
+        .toUriString();
+
+    assertEquals(response, resultResponse);
   }
 
   @Test


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
프론트 측 요청으로, 카카오 로그인 성공시, 결과값을 반환해주는 경로를 수정하였습니다.

- 수정된 클래스
  - UserController
    - UserService에서 전달 받은 경로로 리다이렉트
  - UserService & UserServiceImpl
    - 리다이렉트할 URI 설정

- 테스트 클래스
   - 변경된 코드에 맞게 로직 수정   

## 스크린샷

## 주의사항

Closes #85 
