### PR TITLE
[refactor] Options 요청 JwtFilter 검증 제외 및 토큰 헤더 명 Enum값 사용

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SwaggerConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package com.recipe.jamanchu.config;
 
+import com.recipe.jamanchu.model.type.TokenType;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -21,7 +22,7 @@ public class SwaggerConfig {
         .components(new Components()
             .addSecuritySchemes("bearerAuth",
                 new SecurityScheme()
-                    .name("access-token")
+                    .name(TokenType.ACCESS.getValue())
                     .type(Type.APIKEY)
                     .in(SecurityScheme.In.HEADER)
                     .bearerFormat("JWT")))

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/WebMvcConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package com.recipe.jamanchu.config;
 
+import com.recipe.jamanchu.model.type.TokenType;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -22,6 +23,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
         .allowedMethods(ALLOW_METHOD_NAMES.split(","))  // 허용할 HTTP Method 목록
         .allowedHeaders("*")        // 모든 HTTP header 허용
         .allowCredentials(true)     // 자격 증명 허용
-        .exposedHeaders("access-token", HttpHeaders.LOCATION);   // 클라이언트에 노출할 헤더 목록
+        .exposedHeaders(TokenType.ACCESS.getValue(), HttpHeaders.LOCATION);   // 클라이언트에 노출할 헤더 목록
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/TokenType.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/TokenType.java
@@ -1,0 +1,15 @@
+package com.recipe.jamanchu.model.type;
+
+import lombok.Getter;
+
+@Getter
+public enum TokenType {
+  ACCESS("access-token"),
+  REFRESH("refresh-token");
+
+  private final String value;
+
+  TokenType(String value) {
+    this.value = value;
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/CommentsServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/CommentsServiceImpl.java
@@ -18,6 +18,7 @@ import com.recipe.jamanchu.model.dto.response.comments.Comments;
 import com.recipe.jamanchu.model.dto.response.notify.Notify;
 import com.recipe.jamanchu.model.type.RecipeProvider;
 import com.recipe.jamanchu.model.type.ResultCode;
+import com.recipe.jamanchu.model.type.TokenType;
 import com.recipe.jamanchu.repository.CommentRepository;
 import com.recipe.jamanchu.repository.RecipeRepository;
 import com.recipe.jamanchu.service.CommentsService;
@@ -46,7 +47,7 @@ public class CommentsServiceImpl implements CommentsService {
   public ResultResponse writeComment(HttpServletRequest request, CommentsDTO commentsDTO) {
 
     // Token 검사
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
 
     // 유저 존재 검사
     UserEntity user = userAccessHandler.findByUserId(userId);
@@ -79,7 +80,7 @@ public class CommentsServiceImpl implements CommentsService {
   public ResultResponse updateComment(HttpServletRequest request, CommentsUpdateDTO commentsUpdateDTO) {
 
     // Token 검사
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
 
     // 유저 존재 검사
     UserEntity user = userAccessHandler.findByUserId(userId);
@@ -105,7 +106,7 @@ public class CommentsServiceImpl implements CommentsService {
   public ResultResponse deleteComment(HttpServletRequest request, CommentsDeleteDTO commentsDeleteDTO) {
 
     // Token 검사
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
 
     // 유저 존재 검사
     UserEntity user = userAccessHandler.findByUserId(userId);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -22,6 +22,7 @@ import com.recipe.jamanchu.model.dto.response.recipes.RecipesInfo;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesSummary;
 import com.recipe.jamanchu.model.type.ResultCode;
+import com.recipe.jamanchu.model.type.TokenType;
 import com.recipe.jamanchu.repository.IngredientRepository;
 import com.recipe.jamanchu.repository.ManualRepository;
 import com.recipe.jamanchu.repository.RecipeRatingRepository;
@@ -56,7 +57,7 @@ public class RecipeServiceImpl implements RecipeService {
   @Override
   @Transactional
   public ResultResponse registerRecipe(HttpServletRequest request, RecipesDTO recipesDTO) {
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 
@@ -104,7 +105,7 @@ public class RecipeServiceImpl implements RecipeService {
   @Transactional
   public ResultResponse updateRecipe(HttpServletRequest request,
       RecipesUpdateDTO recipesUpdateDTO) {
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 
@@ -165,7 +166,7 @@ public class RecipeServiceImpl implements RecipeService {
   @Transactional
   public ResultResponse deleteRecipe(HttpServletRequest request,
       RecipesDeleteDTO recipesDeleteDTO) {
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 
@@ -317,7 +318,7 @@ public class RecipeServiceImpl implements RecipeService {
 
   @Override
   public ResultResponse scrapedRecipe(HttpServletRequest request, Long recipeId) {
-    Long userId = jwtUtil.getUserId(request.getHeader("access-token"));
+    Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/CommentsServiceImplTest.java
@@ -18,6 +18,7 @@ import com.recipe.jamanchu.model.dto.request.comments.CommentsDeleteDTO;
 import com.recipe.jamanchu.model.dto.request.comments.CommentsUpdateDTO;
 import com.recipe.jamanchu.model.dto.response.comments.Comments;
 import com.recipe.jamanchu.model.type.RecipeProvider;
+import com.recipe.jamanchu.model.type.TokenType;
 import com.recipe.jamanchu.model.type.UserRole;
 import com.recipe.jamanchu.repository.CommentRepository;
 import com.recipe.jamanchu.repository.RecipeRepository;
@@ -82,7 +83,7 @@ class CommentsServiceImplTest {
     CommentsDTO requestDTO = new CommentsDTO(recipeId, "댓글 내용", 5.0);
 
     // when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(recipeRepository.findById(recipeId)).thenReturn(Optional.of(recipe));
 
@@ -118,7 +119,7 @@ class CommentsServiceImplTest {
     CommentsDTO requestDTO = new CommentsDTO(recipeId, "댓글 내용", 5.0);
 
     // when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(recipeRepository.findById(recipeId)).thenReturn(Optional.of(recipe));
 
@@ -155,7 +156,7 @@ class CommentsServiceImplTest {
     CommentsUpdateDTO requestDTO = new CommentsUpdateDTO(commentId, "새로운 댓글 내용", 4.0);
 
     // when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(oldComment));
 
@@ -205,7 +206,7 @@ class CommentsServiceImplTest {
     CommentsUpdateDTO requestDTO = new CommentsUpdateDTO(commentId, "새로운 댓글 내용", 4.0);
 
     //when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(requestUserId);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(requestUserId);
     when(userAccessHandler.findByUserId(requestUserId)).thenReturn(requestUser);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(oldComment));
 
@@ -237,7 +238,7 @@ class CommentsServiceImplTest {
 
     CommentsDeleteDTO requestDTO = new CommentsDeleteDTO(commentId);
     // when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(userId);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(userId);
     when(userAccessHandler.findByUserId(userId)).thenReturn(user);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
 
@@ -276,7 +277,7 @@ class CommentsServiceImplTest {
 
     CommentsDeleteDTO requestDTO = new CommentsDeleteDTO(commentId);
     // when
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(requestUserId);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(requestUserId);
     when(userAccessHandler.findByUserId(requestUserId)).thenReturn(requestUser);
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -31,6 +31,7 @@ import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesSummary;
 import com.recipe.jamanchu.model.type.CookingTimeType;
 import com.recipe.jamanchu.model.type.LevelType;
+import com.recipe.jamanchu.model.type.TokenType;
 import com.recipe.jamanchu.model.type.UserRole;
 import com.recipe.jamanchu.repository.IngredientRepository;
 import com.recipe.jamanchu.repository.ManualRepository;
@@ -170,7 +171,7 @@ class RecipeServiceImplTest {
   @DisplayName("레시피 등록 성공")
   void registerRecipe_Success() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
 
     // when
@@ -200,7 +201,7 @@ class RecipeServiceImplTest {
         .manuals(manualEntities)
         .build();
 
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(1L)).thenReturn(user);
     when(recipeRepository.findById(1L)).thenReturn(Optional.of(recipe));
     when(ingredientRepository.findAllByRecipeId(1L)).thenReturn(Optional.of(ingredientEntities));
@@ -228,7 +229,7 @@ class RecipeServiceImplTest {
         .userId(2L)
         .build();
 
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(2L);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(2L);
     when(userAccessHandler.findByUserId(requestUser.getUserId())).thenReturn(requestUser);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.ofNullable(recipe));
 
@@ -252,7 +253,7 @@ class RecipeServiceImplTest {
         1L
     );
 
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(1L)).thenReturn(user);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
 
@@ -277,7 +278,7 @@ class RecipeServiceImplTest {
         1L
     );
 
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(2L);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(2L);
     when(userAccessHandler.findByUserId(requestUser.getUserId())).thenReturn(requestUser);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.ofNullable(recipe));
 
@@ -497,7 +498,7 @@ class RecipeServiceImplTest {
   @DisplayName("레시피 스크랩 성공")
   void scrapedRecipe_Success() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(user.getUserId());
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -23,6 +23,7 @@ import com.recipe.jamanchu.model.dto.request.auth.UserUpdateDTO;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.model.dto.response.auth.UserInfoDTO;
 import com.recipe.jamanchu.model.type.ResultCode;
+import com.recipe.jamanchu.model.type.TokenType;
 import com.recipe.jamanchu.model.type.UserRole;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -71,7 +72,7 @@ class UserServiceImplTest {
   private static final String BEFORE_PASSWORD = "oldPassword";
   private static final String AFTER_PASSWORD = "newPassword";
   private static final String NEW_NICKNAME = "newNickName";
-  private static final String ACCESS = "access-token";
+  private static final String ACCESS = TokenType.ACCESS.getValue();
   private static final String REFRESH = "refresh-token";
   private static final String CODE = "kakaoCode";
   private static final String KAKAO_ACCESS_TOKEN = "kakaoAccessToken";
@@ -210,7 +211,7 @@ class UserServiceImplTest {
 
     // then
     String response = UriComponentsBuilder.fromUriString(REDIRECT_URI)
-        .queryParam("access-token", ACCESS)
+        .queryParam(TokenType.ACCESS.getValue(), ACCESS)
         .queryParam("nickname", user.getNickname())
         .build()
         .toUriString();
@@ -243,7 +244,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 성공 - 닉네임, 패스워드 모두 변경")
   void updateUserInfo_SuccessForPasswordAndNickname() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -263,7 +264,7 @@ class UserServiceImplTest {
     // given
     UserUpdateDTO userUpdateDTO = new UserUpdateDTO("nickname", BEFORE_PASSWORD, AFTER_PASSWORD);
 
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -279,7 +280,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 존재하지 않은 회원인 경우")
   void updateUserInfo_NotFoundUser() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
 
     // when then
@@ -291,7 +292,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 비밀번호가 일치하지 않은 경우")
   void updateUserInfo_PasswordMisMatch() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doThrow(new PasswordMismatchException()).when(userAccessHandler)
@@ -306,7 +307,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 카카오로 로그인을 한 회원")
   void updateUserInfo_SocialAccountException() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(kakaoUser);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -322,7 +323,7 @@ class UserServiceImplTest {
   @DisplayName("회원정보 수정 실패 : 닉네임이 중복인 경우")
   void updateUserInfo_DuplicationNickname() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doNothing().when(userAccessHandler).validatePassword(user.getPassword(), BEFORE_PASSWORD);
@@ -341,7 +342,7 @@ class UserServiceImplTest {
   void deleteUser_Success() {
 
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
     doNothing().when(userAccessHandler)
         .validatePassword(user.getPassword(), deleteUserDTO.getPassword());
@@ -358,7 +359,7 @@ class UserServiceImplTest {
   void deleteUser_Success_SocialAccount() {
 
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(kakaoUser);
 
     // when
@@ -372,7 +373,7 @@ class UserServiceImplTest {
   @DisplayName("회원 탈퇴 실패 : 존재하지 않은 회원인 경우")
   void deleteUser_NotFoundUser() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
 
     // when then
@@ -385,7 +386,7 @@ class UserServiceImplTest {
   void deleteUser_PasswordMisMatch() {
 
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     doThrow(new PasswordMismatchException()).when(userAccessHandler)
@@ -400,7 +401,7 @@ class UserServiceImplTest {
   @DisplayName("회원 정보 조회 성공")
   void getUserInfo_Success() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     // when
@@ -416,7 +417,7 @@ class UserServiceImplTest {
   @DisplayName("회원 정보 조회 실패 : 존재하지 않은 사용자")
   void getUserInfo_NotFoundUser() {
     // given
-    when(jwtUtil.getUserId(request.getHeader("access-token"))).thenReturn(USERID);
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(USERID);
     when(userAccessHandler.findByUserId(USERID)).thenThrow(new UserNotFoundException());
 
     // when then


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 클라이언트 측에서 요청을 보낼때 Options 요청도 JwtFilter에서 검증을 받습니다. 이를 해결하기 위해, JwtFilter 클래스에 Options 요청은 제외 시키도록 조건문을 추가하였습니다.

- "access-token" 헤더명을 Enum 값으로 설정할 수 있도록 수정하였습니다.

- 쿠키타입을 Cookie -> ResponseCookie 타입으로 변경을 하였습니다.
   - ResponseCookie로 변경한 이유는 쿠키의 세부적인 설정을 하기 위해서 변경을 했습니다.
      - CORS 문제: 크로스 도메인 요청에서 쿠키를 전송하려면 서버에서 CORS 설정을 정확하게 해야 하며, SameSite=None과 Secure=true 속성을 설정해야 쿠키가 정상적으로 전송됩니다. 


## 스크린샷

## 주의사항

Closes #87 
