### PR TITLE
[fix] 레시피 API permit 수정

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -54,10 +54,12 @@ public class SecurityConfig {
                 "/api/v1/users/signup",
                 "/api/v1/users/login",
                 "/api/v1/users/test",
-                "/api/v1/recipes/**",
                 "/api/v1/auth/email-check",
                 "/favicon.ico",
                 "/api/v1/users/login/auth/kakao").permitAll()
+            .requestMatchers(HttpMethod.GET,
+                "/api/v1/recipes",
+                "/api/v1/recipes/**").permitAll()
             .anyRequest().authenticated());
     http
         .addFilterBefore(new JwtFilter(jwtUtil, userDetailService),


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- SecurityConfig에서 recipes 관련 API에 대한 permit 수정
- permitAll 로 되어 있어서 권한이 필요하지 않은 api(GET)와 권한이 필요한 나머지 api에 대해 동작에 대한 오작동 발생
- GET 메서드에 대해서만 permit 설정
## 스크린샷

## 주의사항

Closes #92 
