### PR TITLE
[feat] 레시피 찜하기 취소 기능 추가

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/ScrapedRecipeEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/ScrapedRecipeEntity.java
@@ -44,4 +44,7 @@ public class ScrapedRecipeEntity extends BaseTimeEntity{
   @Enumerated(EnumType.STRING)
   private ScrapedType scrapedType;
 
+  public void updateScrapedType(ScrapedType scrapedType) {
+    this.scrapedType = scrapedType;
+  }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/ScrapedRecipeEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/ScrapedRecipeEntity.java
@@ -1,7 +1,10 @@
 package com.recipe.jamanchu.entity;
 
+import com.recipe.jamanchu.model.type.ScrapedType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -36,5 +39,9 @@ public class ScrapedRecipeEntity extends BaseTimeEntity{
   @ManyToOne
   @JoinColumn(name = "usr_id")
   private UserEntity user;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private ScrapedType scrapedType;
 
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
@@ -26,6 +26,7 @@ public enum ResultCode {
   SUCCESS_RETRIEVE_RECIPES_DETAILS(HttpStatus.OK, "레시피 상세 조회 성공"),
   SUCCESS_RETRIEVE_ALL_RECIPES_BY_RATING(HttpStatus.OK, "인기 레시피 조회 성공"),
   SUCCESS_SCRAPED_RECIPE(HttpStatus.OK, "레시피 찜하기 성공"),
+  SUCCESS_CANCELED_SCRAP_RECIPE(HttpStatus.OK, "레시피 찜하기 취소 성공"),
   SUCCESS_LOGIN(HttpStatus.OK, "로그인 성공"),
   EMAIL_AVAILABLE(HttpStatus.NO_CONTENT, "사용할 수 있는 이메일입니다."),
   EMAIL_ALREADY_IN_USE(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ScrapedType.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ScrapedType.java
@@ -1,0 +1,11 @@
+package com.recipe.jamanchu.model.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public enum ScrapedType {
+
+  SCRAPED,
+  CANCELED
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/ScrapedRecipeRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/ScrapedRecipeRepository.java
@@ -1,10 +1,13 @@
 package com.recipe.jamanchu.repository;
 
+import com.recipe.jamanchu.entity.RecipeEntity;
 import com.recipe.jamanchu.entity.ScrapedRecipeEntity;
+import com.recipe.jamanchu.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ScrapedRecipeRepository extends JpaRepository<ScrapedRecipeEntity, Long> {
 
+  ScrapedRecipeEntity findByUserAndRecipe(UserEntity user, RecipeEntity recipe);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -21,6 +21,7 @@ import com.recipe.jamanchu.model.dto.response.recipes.RecipesInfo;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesSummary;
 import com.recipe.jamanchu.model.type.ResultCode;
+import com.recipe.jamanchu.model.type.ScrapedType;
 import com.recipe.jamanchu.model.type.TokenType;
 import com.recipe.jamanchu.repository.IngredientRepository;
 import com.recipe.jamanchu.repository.ManualRepository;
@@ -316,13 +317,27 @@ public class RecipeServiceImpl implements RecipeService {
     RecipeEntity recipe = recipeRepository.findById(recipeId)
         .orElseThrow(RecipeNotFoundException::new);
 
-    ScrapedRecipeEntity scrapedRecipe = ScrapedRecipeEntity.builder()
-        .user(user)
-        .recipe(recipe)
-        .build();
+    ScrapedRecipeEntity scrapedRecipe = scrapedRecipeRepository.findByUserAndRecipe(user, recipe);
+
+    if (scrapedRecipe != null) {
+      scrapedRecipe = ScrapedRecipeEntity.builder()
+          .scrapedRecipeId(scrapedRecipe.getScrapedRecipeId())
+          .user(scrapedRecipe.getUser())
+          .recipe(scrapedRecipe.getRecipe())
+          .scrapedType(scrapedRecipe.getScrapedType() == ScrapedType.SCRAPED
+              ? ScrapedType.CANCELED
+              : ScrapedType.SCRAPED)
+          .build();
+    } else {
+      scrapedRecipe = ScrapedRecipeEntity.builder()
+          .user(user)
+          .recipe(recipe)
+          .scrapedType(ScrapedType.SCRAPED)
+          .build();
+    }
 
     scrapedRecipeRepository.save(scrapedRecipe);
 
-    return ResultResponse.of(ResultCode.SUCCESS_SCRAPED_RECIPE);
+    return ResultResponse.of(ResultCode.SUCCESS_SCRAPED_RECIPE, scrapedRecipe.getScrapedType());
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -338,6 +338,9 @@ public class RecipeServiceImpl implements RecipeService {
 
     scrapedRecipeRepository.save(scrapedRecipe);
 
-    return ResultResponse.of(ResultCode.SUCCESS_SCRAPED_RECIPE, scrapedRecipe.getScrapedType());
+    return ResultResponse.of(
+        scrapedRecipe.getScrapedType() == ScrapedType.SCRAPED
+            ? ResultCode.SUCCESS_SCRAPED_RECIPE
+            : ResultCode.SUCCESS_CANCELED_SCRAP_RECIPE, scrapedRecipe.getScrapedType());
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -320,14 +320,9 @@ public class RecipeServiceImpl implements RecipeService {
     ScrapedRecipeEntity scrapedRecipe = scrapedRecipeRepository.findByUserAndRecipe(user, recipe);
 
     if (scrapedRecipe != null) {
-      scrapedRecipe = ScrapedRecipeEntity.builder()
-          .scrapedRecipeId(scrapedRecipe.getScrapedRecipeId())
-          .user(scrapedRecipe.getUser())
-          .recipe(scrapedRecipe.getRecipe())
-          .scrapedType(scrapedRecipe.getScrapedType() == ScrapedType.SCRAPED
-              ? ScrapedType.CANCELED
-              : ScrapedType.SCRAPED)
-          .build();
+      scrapedRecipe.updateScrapedType(scrapedRecipe.getScrapedType() == ScrapedType.SCRAPED
+          ? ScrapedType.CANCELED
+          : ScrapedType.SCRAPED);
     } else {
       scrapedRecipe = ScrapedRecipeEntity.builder()
           .user(user)

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -502,7 +502,7 @@ class RecipeServiceImplTest {
     ResultResponse result = recipeService.scrapedRecipe(request, recipe.getId());
 
     // then
-    assertEquals("레시피 찜하기 성공", result.getMessage());
+    assertEquals("레시피 찜하기 취소 성공", result.getMessage());
     assertEquals(ScrapedType.CANCELED, result.getData()); // SCRAPED -> CANCELED
 
     // verify

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -15,6 +15,7 @@ import com.recipe.jamanchu.entity.IngredientEntity;
 import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.entity.RecipeEntity;
 import com.recipe.jamanchu.entity.RecipeRatingEntity;
+import com.recipe.jamanchu.entity.ScrapedRecipeEntity;
 import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.exceptions.exception.RecipeNotFoundException;
 import com.recipe.jamanchu.exceptions.exception.UnmatchedUserException;
@@ -29,6 +30,7 @@ import com.recipe.jamanchu.model.dto.response.recipes.RecipesManual;
 import com.recipe.jamanchu.model.dto.response.recipes.RecipesSummary;
 import com.recipe.jamanchu.model.type.CookingTimeType;
 import com.recipe.jamanchu.model.type.LevelType;
+import com.recipe.jamanchu.model.type.ScrapedType;
 import com.recipe.jamanchu.model.type.TokenType;
 import com.recipe.jamanchu.model.type.UserRole;
 import com.recipe.jamanchu.repository.IngredientRepository;
@@ -482,20 +484,77 @@ class RecipeServiceImplTest {
   }
 
   @Test
-  @DisplayName("레시피 스크랩 성공")
-  void scrapedRecipe_Success() {
+  @DisplayName("레시피 스크랩 취소 - SCRAPED -> CANCELED")
+  void scrapedRecipe_Success_ScrapedToCanceled() {
     // given
+    ScrapedRecipeEntity scrapedRecipe = ScrapedRecipeEntity.builder()
+        .user(user)
+        .recipe(recipe)
+        .scrapedType(ScrapedType.SCRAPED)
+        .build();
+
     when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
     when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
+    when(scrapedRecipeRepository.findByUserAndRecipe(user, recipe)).thenReturn(scrapedRecipe);
 
     // when
     ResultResponse result = recipeService.scrapedRecipe(request, recipe.getId());
 
     // then
     assertEquals("레시피 찜하기 성공", result.getMessage());
+    assertEquals(ScrapedType.CANCELED, result.getData()); // SCRAPED -> CANCELED
 
     // verify
+    verify(scrapedRecipeRepository, times(1)).findByUserAndRecipe(any(), any());
+    verify(scrapedRecipeRepository, times(1)).save(any());
+  }
+
+  @Test
+  @DisplayName("레시피 스크랩 성공 - CANCELED -> SCRAPED")
+  void scrapedRecipe_Success_CanceledToScraped() {
+    // given
+    ScrapedRecipeEntity scrapedRecipe = ScrapedRecipeEntity.builder()
+        .user(user)
+        .recipe(recipe)
+        .scrapedType(ScrapedType.CANCELED)
+        .build();
+
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(user.getUserId());
+    when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
+    when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
+    when(scrapedRecipeRepository.findByUserAndRecipe(user, recipe)).thenReturn(scrapedRecipe);
+
+    // when
+    ResultResponse result = recipeService.scrapedRecipe(request, recipe.getId());
+
+    // then
+    assertEquals("레시피 찜하기 성공", result.getMessage());
+    assertEquals(ScrapedType.SCRAPED, result.getData());
+
+    // verify
+    verify(scrapedRecipeRepository, times(1)).findByUserAndRecipe(any(), any());
+    verify(scrapedRecipeRepository, times(1)).save(any());
+  }
+
+  @Test
+  @DisplayName("레시피 스크랩 성공 - 기존 스크랩 없음")
+  void scrapedRecipe_Success_NewScraped() {
+    // given
+    when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(user.getUserId());
+    when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
+    when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
+    when(scrapedRecipeRepository.findByUserAndRecipe(user, recipe)).thenReturn(null); // 기존 스크랩 없음
+
+    // when
+    ResultResponse result = recipeService.scrapedRecipe(request, recipe.getId());
+
+    // then
+    assertEquals("레시피 찜하기 성공", result.getMessage());
+    assertEquals(ScrapedType.SCRAPED, result.getData());
+
+    // verify
+    verify(scrapedRecipeRepository, times(1)).findByUserAndRecipe(any(), any());
     verify(scrapedRecipeRepository, times(1)).save(any());
   }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- ScrapedType Enum 추가 (SCRAPED, CANCELED)
- ScrapedRecipeEntity에 ScrapedType 추가
- ScrapedRecipeRepository 클래스에서 userId 와 recipeId에 해당하는 찜 레시피 가져오는 쿼리 추가
- 찜 레시피가 존재한다면 ScrapedType을 변경하고 data 리턴
  - SCRAPED / CANCELED 값을 프론트로 리턴
- 찜 레시피가 존재하지 않는다면, 찜 레시피에 등록(SCRAPED)
- 수정된 부분에 대해 테스트 코드 추가 및 수정
## 스크린샷
- 테스트 진행 결과
![스크린샷 2024-10-15 오전 12 09 36](https://github.com/user-attachments/assets/89adefd1-0f2b-49c7-86e8-75c833a5e5b1)

## 주의사항

Closes #97 
