### PR TITLE
[fix] comment DTO와 CommentEntity Fetch Type 변경

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/CommentEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/CommentEntity.java
@@ -2,6 +2,7 @@ package com.recipe.jamanchu.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,8 +34,8 @@ public class CommentEntity extends BaseTimeEntity{
   private UserEntity user;
 
   @NotNull
-  @ManyToOne
-  @JoinColumn(name = "rcp_id")
+  @ManyToOne(optional = false,fetch = FetchType.LAZY)
+  @JoinColumn(name = "rcp_id", nullable = false)
   private RecipeEntity recipe;
 
   @NotNull

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/comments/CommentsDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/comments/CommentsDTO.java
@@ -21,8 +21,8 @@ public class CommentsDTO {
   @JsonProperty("comment")
   private final String comment;
 
-  @DecimalMin(value = "1.0", inclusive = false, message = "평점은 1.0 이상으로 입력해주세요.")
-  @DecimalMax(value = "5.0", inclusive = false, message = "평점은 5.0 이하로 입력해주세요.")
+  @DecimalMin(value = "1.0", message = "평점은 1.0 이상으로 입력해주세요.")
+  @DecimalMax(value = "5.0", message = "평점은 5.0 이하로 입력해주세요.")
   @JsonProperty("rating")
   private final Double rating;
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용

1. CommentsDTO 에석 DecimalMin과 DecimalMax에 대해 inclusive 속성 제외
2. CommentEntity 내부 Fetch Type을 LAZY로 변경

### LAZY로 변경한 이유

기존의 삭제로직에서 CommentsEntity는 RecipeEntity를 Fetch Type의 기본형인 EAGER를 사용하고 있었음. 

이런 경우, Comment 조회 시 Recipe를 즉시 로딩하게 되는데, Recipe에서도 Comments를 순환 참조하고 있었음.

첫번째로 Comments로 조회할 때, 삭제하려는 CommentsEntity가 영속화 되고 Recipe에서 해당 레시피 하위에 존재하는 Comments를 즉시 조회하게 되면서, 삭제하려는 CommentsEntity가 2번 영속화 되는 문제 발생.

일반적으로 댓글을 삭제해도 게시글에는 영향을 주지 않기 때문에, CommentsEntity 삭제 시에도 Recipe를 추가로 조회할 이유가 없어서 LAZY로 fetch 타입을 변경. 

이후에 정상적으로 동작  

## 스크린샷

## 주의사항

Closes #103 