### PR TITLE
[feat] 레시피 등록 및 수정시에 MappingTable에도 내용 저장되도록 구현

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/IngredientRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/IngredientRepository.java
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface IngredientRepository extends JpaRepository<IngredientEntity, Long> {
 
-  Optional<List<IngredientEntity>> findAllByRecipeId(Long recipeId);
-
   @Modifying
   @Query("DELETE FROM IngredientEntity i WHERE i.recipe.id = :recipeId")
   void deleteAllByRecipeId(@Param("recipeId") Long recipeId);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeIngredientMappingRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeIngredientMappingRepository.java
@@ -13,8 +13,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RecipeIngredientMappingRepository extends JpaRepository<RecipeIngredientMappingEntity, RecipeIngredientMappingId> {
 
-  Optional<List<RecipeIngredientMappingEntity>> findAllByRecipeId(Long recipeId);
-
   @Modifying
   @Query("DELETE FROM RecipeIngredientMappingEntity r WHERE r.recipe.id = :recipeId")
   void deleteAllByRecipeId(@Param("recipeId") Long recipeId);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeIngredientMappingRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeIngredientMappingRepository.java
@@ -2,10 +2,20 @@ package com.recipe.jamanchu.repository;
 
 import com.recipe.jamanchu.entity.RecipeIngredientMappingEntity;
 import com.recipe.jamanchu.util.RecipeIngredientMappingId;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecipeIngredientMappingRepository extends JpaRepository<RecipeIngredientMappingEntity, RecipeIngredientMappingId> {
 
+  Optional<List<RecipeIngredientMappingEntity>> findAllByRecipeId(Long recipeId);
+
+  @Modifying
+  @Query("DELETE FROM RecipeIngredientMappingEntity r WHERE r.recipe.id = :recipeId")
+  void deleteAllByRecipeId(@Param("recipeId") Long recipeId);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -7,6 +7,7 @@ import com.recipe.jamanchu.component.UserAccessHandler;
 import com.recipe.jamanchu.entity.IngredientEntity;
 import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.entity.RecipeEntity;
+import com.recipe.jamanchu.entity.RecipeIngredientMappingEntity;
 import com.recipe.jamanchu.entity.ScrapedRecipeEntity;
 import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.exceptions.exception.RecipeNotFoundException;
@@ -25,6 +26,7 @@ import com.recipe.jamanchu.model.type.ScrapedType;
 import com.recipe.jamanchu.model.type.TokenType;
 import com.recipe.jamanchu.repository.IngredientRepository;
 import com.recipe.jamanchu.repository.ManualRepository;
+import com.recipe.jamanchu.repository.RecipeIngredientMappingRepository;
 import com.recipe.jamanchu.repository.RecipeRatingRepository;
 import com.recipe.jamanchu.repository.RecipeRepository;
 import com.recipe.jamanchu.repository.ScrapedRecipeRepository;
@@ -51,6 +53,7 @@ public class RecipeServiceImpl implements RecipeService {
   private final ManualRepository manualRepository;
   private final ScrapedRecipeRepository scrapedRecipeRepository;
   private final RecipeRatingRepository recipeRatingRepository;
+  private final RecipeIngredientMappingRepository recipeIngredientMappingRepository;
   private final UserAccessHandler userAccessHandler;
   private final JwtUtil jwtUtil;
 
@@ -83,7 +86,19 @@ public class RecipeServiceImpl implements RecipeService {
       ingredients.add(ingredient);
     }
 
-    ingredientRepository.saveAll(ingredients);
+    ingredientRepository.saveAllAndFlush(ingredients);
+
+    List<RecipeIngredientMappingEntity> recipeIngredientMappings = new ArrayList<>();
+    for (IngredientEntity ingredient : ingredients) {
+      RecipeIngredientMappingEntity mapping = RecipeIngredientMappingEntity.builder()
+          .recipe(recipe)
+          .ingredient(ingredient)
+          .build();
+
+      recipeIngredientMappings.add(mapping);
+    }
+
+    recipeIngredientMappingRepository.saveAll(recipeIngredientMappings);
 
     List<ManualEntity> manuals = new ArrayList<>();
     for (int i = 0; i < recipesDTO.getRecipeOrderContents().size(); i++) {
@@ -122,10 +137,13 @@ public class RecipeServiceImpl implements RecipeService {
         recipesUpdateDTO.getRecipeLevel(), recipesUpdateDTO.getRecipeCookingTime(),
         String.valueOf(recipesUpdateDTO.getRecipeThumbnail()));
 
-    // 기존 recipeId로 저장된 재료 확인
+    // 기존 recipeId로 저장된 재료 확인 및 삭제
+    recipeIngredientMappingRepository.findAllByRecipeId(recipeId)
+        .orElseThrow(RecipeNotFoundException::new);
+    recipeIngredientMappingRepository.deleteAllByRecipeId(recipeId);
+
     ingredientRepository.findAllByRecipeId(recipeId)
         .orElseThrow(RecipeNotFoundException::new);
-    // 기존 recipeId로 저장된 재료 리스트 삭제
     ingredientRepository.deleteAllByRecipeId(recipeId);
 
     List<IngredientEntity> ingredients = new ArrayList<>();
@@ -139,7 +157,19 @@ public class RecipeServiceImpl implements RecipeService {
       ingredients.add(ingredient);
     }
 
-    ingredientRepository.saveAll(ingredients);
+    ingredientRepository.saveAllAndFlush(ingredients);
+
+    List<RecipeIngredientMappingEntity> recipeIngredientMappings = new ArrayList<>();
+    for (IngredientEntity ingredient : ingredients) {
+      RecipeIngredientMappingEntity mapping = RecipeIngredientMappingEntity.builder()
+          .recipe(recipe)
+          .ingredient(ingredient)
+          .build();
+
+      recipeIngredientMappings.add(mapping);
+    }
+
+    recipeIngredientMappingRepository.saveAll(recipeIngredientMappings);
 
     manualRepository.findAllByRecipeId(recipeId)
         .orElseThrow(RecipeNotFoundException::new);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -86,7 +86,7 @@ public class RecipeServiceImpl implements RecipeService {
       ingredients.add(ingredient);
     }
 
-    ingredientRepository.saveAllAndFlush(ingredients);
+    ingredientRepository.saveAll(ingredients);
 
     List<RecipeIngredientMappingEntity> recipeIngredientMappings = new ArrayList<>();
     for (IngredientEntity ingredient : ingredients) {
@@ -157,7 +157,7 @@ public class RecipeServiceImpl implements RecipeService {
       ingredients.add(ingredient);
     }
 
-    ingredientRepository.saveAllAndFlush(ingredients);
+    ingredientRepository.saveAll(ingredients);
 
     List<RecipeIngredientMappingEntity> recipeIngredientMappings = new ArrayList<>();
     for (IngredientEntity ingredient : ingredients) {

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -137,13 +137,8 @@ public class RecipeServiceImpl implements RecipeService {
         recipesUpdateDTO.getRecipeLevel(), recipesUpdateDTO.getRecipeCookingTime(),
         String.valueOf(recipesUpdateDTO.getRecipeThumbnail()));
 
-    // 기존 recipeId로 저장된 재료 확인 및 삭제
-    recipeIngredientMappingRepository.findAllByRecipeId(recipeId)
-        .orElseThrow(RecipeNotFoundException::new);
+    // 기존 recipeId로 저장된 재료 삭제
     recipeIngredientMappingRepository.deleteAllByRecipeId(recipeId);
-
-    ingredientRepository.findAllByRecipeId(recipeId)
-        .orElseThrow(RecipeNotFoundException::new);
     ingredientRepository.deleteAllByRecipeId(recipeId);
 
     List<IngredientEntity> ingredients = new ArrayList<>();
@@ -170,9 +165,6 @@ public class RecipeServiceImpl implements RecipeService {
     }
 
     recipeIngredientMappingRepository.saveAll(recipeIngredientMappings);
-
-    manualRepository.findAllByRecipeId(recipeId)
-        .orElseThrow(RecipeNotFoundException::new);
 
     manualRepository.deleteAllByRecipeId(recipeId);
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -221,9 +221,6 @@ class RecipeServiceImplTest {
     when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(1L)).thenReturn(user);
     when(recipeRepository.findById(1L)).thenReturn(Optional.of(recipe));
-    when(ingredientRepository.findAllByRecipeId(1L)).thenReturn(Optional.of(ingredientEntities));
-    when(recipeIngredientMappingRepository.findAllByRecipeId(1L)).thenReturn(Optional.of(recipeIngredientMappings));
-    when(manualRepository.findAllByRecipeId(1L)).thenReturn(Optional.of(manualEntities));
 
     // When
     ResultResponse result = recipeService.updateRecipe(request, recipesUpdateDTO);
@@ -233,10 +230,8 @@ class RecipeServiceImplTest {
 
     // verify
     verify(recipeRepository, times(1)).findById(1L);
-    verify(ingredientRepository, times(1)).findAllByRecipeId(1L);
     verify(ingredientRepository, times(1)).deleteAllByRecipeId(1L);
     verify(ingredientRepository, times(1)).saveAll(anyList());
-    verify(recipeIngredientMappingRepository, times(1)).findAllByRecipeId(1L);
     verify(recipeIngredientMappingRepository, times(1)).deleteAllByRecipeId(1L);
     verify(recipeIngredientMappingRepository, times(1)).saveAll(anyList());
     verify(manualRepository, times(1)).deleteAllByRecipeId(1L);

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -177,7 +177,7 @@ class RecipeServiceImplTest {
     // given
     when(jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()))).thenReturn(user.getUserId());
     when(userAccessHandler.findByUserId(user.getUserId())).thenReturn(user);
-    when(ingredientRepository.saveAllAndFlush(anyList())).thenReturn(new ArrayList<>());
+    when(ingredientRepository.saveAll(anyList())).thenReturn(new ArrayList<>());
     when(recipeIngredientMappingRepository.saveAll(anyList())).thenReturn(new ArrayList<>());
 
     // when
@@ -188,7 +188,7 @@ class RecipeServiceImplTest {
 
     // verify
     verify(recipeRepository, times(1)).save(any(RecipeEntity.class));
-    verify(ingredientRepository, times(1)).saveAllAndFlush(anyList());
+    verify(ingredientRepository, times(1)).saveAll(anyList());
     verify(recipeIngredientMappingRepository, times(1)).saveAll(anyList());
     verify(manualRepository, times(1)).saveAll(anyList());
   }
@@ -235,7 +235,7 @@ class RecipeServiceImplTest {
     verify(recipeRepository, times(1)).findById(1L);
     verify(ingredientRepository, times(1)).findAllByRecipeId(1L);
     verify(ingredientRepository, times(1)).deleteAllByRecipeId(1L);
-    verify(ingredientRepository, times(1)).saveAllAndFlush(anyList());
+    verify(ingredientRepository, times(1)).saveAll(anyList());
     verify(recipeIngredientMappingRepository, times(1)).findAllByRecipeId(1L);
     verify(recipeIngredientMappingRepository, times(1)).deleteAllByRecipeId(1L);
     verify(recipeIngredientMappingRepository, times(1)).saveAll(anyList());


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 레시피 등록 및 수정 시에 RecipeIngredientMappingEntity에도 재료에 관한 부분이 저장되도록 추가
- 레시피 등록시에 RecipeIngredientMappingEntity에 저장하려면, Ingredient 정보가 있어야 해서 재료 정보 SaveAll 이후에 Mapping 정보 추가
- 레시피 수정시에는 Mapping 관계 때문에 저장 순서와 반대로 삭제 구현
- 수정된 사항에 대해서 테스트 코드도 수정 완료
## 스크린샷

## 주의사항

Closes #106 
