### PR TITLE
[fix] 재료명 사이에 빈칸이 있을 경우 처리 추가

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeDivideServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeDivideServiceImpl.java
@@ -124,13 +124,18 @@ public class RecipeDivideServiceImpl implements RecipeDivideService {
       }
 
       String[] parts = ingredient.split(" ");  // 재료명과 수량 분리
-      String name = parts[0];
+      StringBuilder sb = new StringBuilder();
       String quantity = "";
+      if (parts.length == 1) {
+        sb.append(parts[0]);
+      } else {
+        for (int i = 0; i < parts.length - 1; i++) {
+          sb.append(parts[i]).append(" ");
+        }
 
-      // 수량이 있을 경우에만 parts[1]에 접근
-      if (parts.length > 1) {
-        quantity = parts[1];
+        quantity = parts[parts.length - 1];
       }
+      String name = sb.toString().trim();
 
       IngredientEntity ingredientEntity = IngredientEntity.builder()
           .recipe(recipe)

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeDivideServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeDivideServiceImpl.java
@@ -4,6 +4,7 @@ import com.recipe.jamanchu.component.UserAccessHandler;
 import com.recipe.jamanchu.entity.IngredientEntity;
 import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.entity.RecipeEntity;
+import com.recipe.jamanchu.entity.RecipeIngredientMappingEntity;
 import com.recipe.jamanchu.entity.RecipeRatingEntity;
 import com.recipe.jamanchu.entity.TenThousandRecipeEntity;
 import com.recipe.jamanchu.entity.UserEntity;
@@ -12,10 +13,12 @@ import com.recipe.jamanchu.model.type.RecipeProvider;
 import com.recipe.jamanchu.model.type.ResultCode;
 import com.recipe.jamanchu.repository.IngredientRepository;
 import com.recipe.jamanchu.repository.ManualRepository;
+import com.recipe.jamanchu.repository.RecipeIngredientMappingRepository;
 import com.recipe.jamanchu.repository.RecipeRatingRepository;
 import com.recipe.jamanchu.repository.RecipeRepository;
 import com.recipe.jamanchu.repository.TenThousandRecipeRepository;
 import com.recipe.jamanchu.service.RecipeDivideService;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -30,6 +33,7 @@ public class RecipeDivideServiceImpl implements RecipeDivideService {
   private final RecipeRatingRepository recipeRatingRepository;
   private final ManualRepository manualRepository;
   private final IngredientRepository ingredientRepository;
+  private final RecipeIngredientMappingRepository recipeIngredientMappingRepository;
   private final TenThousandRecipeRepository tenThousandRecipeRepository;
 
   @Override
@@ -99,6 +103,7 @@ public class RecipeDivideServiceImpl implements RecipeDivideService {
   public void saveManualData(RecipeEntity recipe, TenThousandRecipeEntity scrapedRecipe) {
     String[] contents = scrapedRecipe.getCrManualContents().split("\\$%\\^");
     String[] pictures;
+    List<ManualEntity> manualEntities = new ArrayList<>();
     if(scrapedRecipe.getCrManualPictures() == null || scrapedRecipe.getCrManualPictures().isEmpty()) {
       pictures = new String[contents.length];
     } else {
@@ -111,8 +116,9 @@ public class RecipeDivideServiceImpl implements RecipeDivideService {
           .manualPicture(pictures[i] != null ? pictures[i] : "")
           .build();
 
-      manualRepository.save(manual);
+      manualEntities.add(manual);
     }
+    manualRepository.saveAll(manualEntities);
   }
 
   public void saveIngredientDetails(RecipeEntity recipe, TenThousandRecipeEntity scrapedRecipe) {

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeDivideServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeDivideServiceImpl.java
@@ -117,6 +117,8 @@ public class RecipeDivideServiceImpl implements RecipeDivideService {
 
   public void saveIngredientDetails(RecipeEntity recipe, TenThousandRecipeEntity scrapedRecipe) {
     String[] ingredients = scrapedRecipe.getIngredients().split(",");  // 재료 분리 로직
+    List<IngredientEntity> ingredientEntities = new ArrayList<>();
+    List<RecipeIngredientMappingEntity> recipeIngredientMappingEntities = new ArrayList<>();
     for (String ingredient : ingredients) {
       ingredient = ingredient.trim();
       if (ingredient.isEmpty()) {
@@ -143,7 +145,16 @@ public class RecipeDivideServiceImpl implements RecipeDivideService {
           .quantity(quantity)
           .build();
 
-      ingredientRepository.save(ingredientEntity);
+      ingredientEntities.add(ingredientEntity);
+
+      RecipeIngredientMappingEntity recipeIngredientMappingEntity = RecipeIngredientMappingEntity.builder()
+          .recipe(recipe)
+          .ingredient(ingredientEntity)
+          .build();
+
+      recipeIngredientMappingEntities.add(recipeIngredientMappingEntity);
     }
+    ingredientRepository.saveAll(ingredientEntities);
+    recipeIngredientMappingRepository.saveAll(recipeIngredientMappingEntities);
   }
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 재료에 대한 부분이 들어와서 빈칸을 기준으로 split을 해줬었는데, split 배열의 마지막 항목을 수량으로 처리하고, 그 앞에 있는 내용들은 전부 모아서 재료명으로 처리하도록 구현
- 가독성을 위해서 재료명 저장할 때에는 사이에 빈 칸 유지
- 재료 저장할 때 MappingEntity 에도 내용 저장되도록 추가
- 재료 및 재료매핑 부분 saveAll 로 한번에 데이터 저장할 수 있도록 수정
- manual 부분도 saveAll로 수정
- 테스트 코드 수정 완료

## 스크린샷

## 주의사항

Closes #110 
