### PR TITLE
[feat] refresh 토큰 재발급 로직 구현

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -1,152 +1,89 @@
 package com.recipe.jamanchu.auth.jwt;
 
-import com.recipe.jamanchu.auth.service.CustomUserDetailService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.recipe.jamanchu.model.type.TokenType;
-import com.recipe.jamanchu.model.type.UserRole;
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
   private final JwtUtil jwtUtil;
-  private final CustomUserDetailService userDetailService;
-  private final Logger logger = LoggerFactory.getLogger(JwtFilter.class);
 
   @Override
-  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-      FilterChain filterChain)
+  protected void doFilterInternal(HttpServletRequest request,
+      HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
 
-    // Options 요청시 jwt 검증 제외
-    if(request.getMethod().equals(HttpMethod.OPTIONS.name())) {
+    // Options 요청 및 인증이 필요없는 경로 토큰 검증 제외
+    if (HttpMethod.OPTIONS.matches(request.getMethod())
+        || isExcludedPath(request.getRequestURI())) {
+
       filterChain.doFilter(request, response);
       return;
     }
 
-    String requestURI = request.getRequestURI();
-    logger.info("requestURI -> {}", requestURI);
+    // Header에서 Access-Token 추출
+    String tokenHeader = request.getHeader(TokenType.ACCESS.getValue());
 
-    // 인증이 필요 없는 경로
-    if (isExcludedPath(requestURI)) {
+    // Bearer 시작 여부 및 null 값 검증
+    if (tokenHeader == null || !tokenHeader.startsWith("Bearer ")) {
+      log.info("Invalid or missing access-token");
       filterChain.doFilter(request, response);
       return;
     }
 
-    String authorizationHeader = request.getHeader(TokenType.ACCESS.getValue());
-    logger.info("authorizationHeader -> {}", authorizationHeader);
+    String accessToken = tokenHeader.substring(7);
 
-    // Bearer 토큰이 헤더에 있는지 확인
-    if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-      logger.info("access-token is null or doesn't start with Bearer");
-      filterChain.doFilter(request, response);
+    // Access-Token 만료시간 검증
+    if (jwtUtil.isExpired(accessToken)) {
+      log.info("access-token is expired");
+      setResponse(response);
       return;
     }
 
-    String accessToken = authorizationHeader.substring(7);
-
-    try {
-      // access 토큰이 만료가 되지 않은 경우
-      jwtUtil.isExpired(accessToken);
-
-      setAuthenticationFromToken(response, accessToken);
-    } catch (ExpiredJwtException e) {
-      expiredAccessToken(request, response);
-      return;
-    }
-
+    setAuthentication(accessToken);
     filterChain.doFilter(request, response);
   }
 
-  private void setAuthenticationFromToken(HttpServletResponse response, String token) {
-    response.addHeader(TokenType.ACCESS.getValue(), "Bearer " + token);
-
-    Authentication authToken = getAuthToken(token);
-    SecurityContextHolder.getContext().setAuthentication(authToken);
-  }
-
-
-  // access 토큰이 만료되었을 경우 refresh 토큰 검증 후 재 발급
-  private void expiredAccessToken(HttpServletRequest request, HttpServletResponse response)
-      throws IOException {
-    logger.info("access-token is Expired!!");
-    String refreshToken = getRefreshTokenFromCookies(request);
-
-    if (refreshToken == null) {
-      setResponse(response);
-      return;
-    }
-
-    try {
-      jwtUtil.isExpired(refreshToken);
-      String newAccessToken = createNewAccessToken(refreshToken);
-
-      setAuthenticationFromToken(response, newAccessToken);
-    } catch (ExpiredJwtException e) {
-      setResponse(response);
-    }
-  }
-
-  // refresh 토큰 반환
-  private String getRefreshTokenFromCookies(HttpServletRequest request) {
-    Cookie[] cookies = request.getCookies();
-    logger.info("cookies.length -> {}", cookies.length);
-    return Arrays.stream(request.getCookies())
-        .filter(cookie -> TokenType.REFRESH.getValue().equals(cookie.getName()))
-        .map(Cookie::getValue)
-        .findFirst()
-        .orElse(null);
-  }
-
-  private Authentication getAuthToken(String token) {
+  // userId를 추출 및 인증 정보를 설정
+  private void setAuthentication(String token) {
     Long userId = jwtUtil.getUserId(token);
 
-    UserDetails userDetails = userDetailService.loadUserByUsername(userId.toString());
-    return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    Authentication authentication = jwtUtil.getAuthentication(userId.toString());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
   }
 
-  // access 토큰 재발급
-  private String createNewAccessToken(String refreshToken) {
-
-    logger.info("Create New access-token!");
-
-    Long userId = jwtUtil.getUserId(refreshToken);
-    UserRole role = UserRole.valueOf(jwtUtil.getRole(refreshToken));
-
-    return jwtUtil.createJwt("access", userId, role);
-  }
-
-  // 오류 메세지 전송
+  // Access-Token 만료시 401 반환
   private void setResponse(HttpServletResponse response) throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
-    response.getWriter().write("인증 토큰이 만료되었습니다. 다시 로그인해 주세요.");
+
+    Map<String, String> body = Map.of("message", "access-token 만료");
+    response.getWriter().write(objectMapper.writeValueAsString(body));
   }
 
+  // Jwt 검증 제외 경로
   private boolean isExcludedPath(String requestURI) {
     return requestURI.equals("/")
         || requestURI.equals("/api/v1/users/login")
         || requestURI.equals("/api/v1/users/signup")
-        || requestURI.equals("/api/v1/users/test")
         || requestURI.equals("/api/v1/auth/email-check")
-        || requestURI.equals("/api/v1/users/login/auth/kakao");
+        || requestURI.equals("/api/v1/auth/nickname-check")
+        || requestURI.equals("/api/v1/users/login/auth/kakao")
+        || requestURI.equals("/api/v1/auth/token/refresh");
   }
 }
-
-

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/SecurityConfig.java
@@ -53,16 +53,17 @@ public class SecurityConfig {
             .requestMatchers("/",
                 "/api/v1/users/signup",
                 "/api/v1/users/login",
-                "/api/v1/users/test",
                 "/api/v1/auth/email-check",
+                "/api/v1/auth/nickname-check",
                 "/favicon.ico",
-                "/api/v1/users/login/auth/kakao").permitAll()
+                "/api/v1/users/login/auth/kakao",
+                "/api/v1/auth/token/refresh").permitAll()
             .requestMatchers(HttpMethod.GET,
                 "/api/v1/recipes",
                 "/api/v1/recipes/**").permitAll()
             .anyRequest().authenticated());
     http
-        .addFilterBefore(new JwtFilter(jwtUtil, userDetailService),
+        .addFilterBefore(new JwtFilter(jwtUtil),
             UsernamePasswordAuthenticationFilter.class);
     http
         .sessionManagement(session -> session

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/AuthController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.recipe.jamanchu.exceptions.exception.MissingEmailException;
 import com.recipe.jamanchu.exceptions.exception.MissingNicknameException;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +22,9 @@ public class AuthController {
 
 
   @GetMapping("/email-check")
-  public ResponseEntity<ResultResponse> checkEmail(@RequestParam(name = "email", required = false) String email) {
+  public ResponseEntity<ResultResponse> checkEmail(
+      @RequestParam(name = "email", required = false) String email) {
+
     if (email == null) {
       throw new MissingEmailException();
     }
@@ -28,10 +32,20 @@ public class AuthController {
   }
 
   @GetMapping("/nickname-check")
-  public ResponseEntity<ResultResponse> checkNickname(@RequestParam(name = "nickname", required = false) String nickname) {
+  public ResponseEntity<ResultResponse> checkNickname(
+      @RequestParam(name = "nickname", required = false) String nickname) {
+
     if (nickname == null) {
       throw new MissingNicknameException();
     }
     return ResponseEntity.ok(authService.checkNickname(nickname));
   }
+
+  @GetMapping("/token/refresh")
+  public ResponseEntity<ResultResponse> refreshToken(HttpServletRequest request,
+      HttpServletResponse response) {
+
+    return ResponseEntity.ok(authService.refreshToken(request, response));
+  }
+
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/ExceptionStatus.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/ExceptionStatus.java
@@ -18,6 +18,7 @@ public enum ExceptionStatus {
   ACCESS_TOKEN_RETRIEVAL(HttpStatus.UNAUTHORIZED, "액세스 토큰을 가져오는 데 실패했습니다."),
   USER_INFO_RETRIEVAL(HttpStatus.UNAUTHORIZED, "사용자 정보를 가져오는 데 실패했습니다."),
   MISSING_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임을 입력해주세요!"),
+  REFRESH_TOKEN_EXPIRED(HttpStatus.GONE, "다시 로그인을 해주세요!"),
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/ExceptionStatus.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/ExceptionStatus.java
@@ -19,6 +19,7 @@ public enum ExceptionStatus {
   USER_INFO_RETRIEVAL(HttpStatus.UNAUTHORIZED, "사용자 정보를 가져오는 데 실패했습니다."),
   MISSING_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임을 입력해주세요!"),
   REFRESH_TOKEN_EXPIRED(HttpStatus.GONE, "다시 로그인을 해주세요!"),
+  COOKIE_NOT_FOUND(HttpStatus.NOT_FOUND, "다시 로그인을 해주세요!"),
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/exception/CookieNotFoundException.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/exception/CookieNotFoundException.java
@@ -1,0 +1,10 @@
+package com.recipe.jamanchu.exceptions.exception;
+
+import com.recipe.jamanchu.exceptions.ExceptionStatus;
+
+public class CookieNotFoundException extends GlobalException {
+
+  public CookieNotFoundException() {
+    super(ExceptionStatus.COOKIE_NOT_FOUND);
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/exception/RefreshTokenExpiredException.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/exception/RefreshTokenExpiredException.java
@@ -1,0 +1,11 @@
+package com.recipe.jamanchu.exceptions.exception;
+
+import com.recipe.jamanchu.exceptions.ExceptionStatus;
+
+public class RefreshTokenExpiredException extends GlobalException {
+
+  public RefreshTokenExpiredException() {
+
+    super(ExceptionStatus.REFRESH_TOKEN_EXPIRED);
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ResultCode.java
@@ -33,6 +33,7 @@ public enum ResultCode {
   NICKNAME_AVAILABLE(HttpStatus.OK, "사용할 수 있는 닉네임 입니다."),
   NICKNAME_ALREADY_IN_USE(HttpStatus.OK, "이미 사용 중인 닉네임 입니다."),
   SUCCESS_GET_USER_RECIPES_INFO(HttpStatus.OK, "회원 레시피 정보 조회 성공"),
+  SUCCESS_REISSUE_REFRESH_TOKEN(HttpStatus.OK, "access-token 재발급 성공"),
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/AuthService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/AuthService.java
@@ -1,10 +1,14 @@
 package com.recipe.jamanchu.service;
 
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
 
   ResultResponse checkEmail(String email);
 
   ResultResponse checkNickname(String nickname);
+
+  ResultResponse refreshToken(HttpServletRequest request, HttpServletResponse response);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/AuthServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/AuthServiceImpl.java
@@ -2,6 +2,7 @@ package com.recipe.jamanchu.service.impl;
 
 import com.recipe.jamanchu.auth.jwt.JwtUtil;
 import com.recipe.jamanchu.component.UserAccessHandler;
+import com.recipe.jamanchu.exceptions.exception.CookieNotFoundException;
 import com.recipe.jamanchu.exceptions.exception.RefreshTokenExpiredException;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.model.type.ResultCode;
@@ -39,23 +40,32 @@ public class AuthServiceImpl implements AuthService {
   @Override
   public ResultResponse refreshToken(HttpServletRequest request, HttpServletResponse response) {
     Cookie[] cookies = request.getCookies();
+
+    // 쿠키 검증
+    if (cookies == null || cookies.length == 0) {
+      log.info("No cookies found");
+      throw new CookieNotFoundException();
+    }
+
     log.info("cookies.length -> {}", cookies.length);
 
+    // refresh-token 추출
     String refreshToken =  Arrays.stream(request.getCookies())
         .filter(cookie -> TokenType.REFRESH.getValue().equals(cookie.getName()))
         .map(Cookie::getValue)
         .findFirst()
         .orElse(null);
 
+    // refresh-token 검증
     if (refreshToken == null || jwtUtil.isExpired(refreshToken)) {
       throw new RefreshTokenExpiredException();
     }
 
     Long userId = jwtUtil.getUserId(refreshToken);
     UserRole role = UserRole.valueOf(jwtUtil.getRole(refreshToken));
-
     String access = jwtUtil.createJwt("access", userId, role);
 
+    log.info("access-token 재발급 성공!!!");
     response.addHeader(TokenType.ACCESS.getValue(), "Bearer " + access);
 
     return ResultResponse.of(ResultCode.SUCCESS_REISSUE_REFRESH_TOKEN);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/AuthServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/AuthServiceImpl.java
@@ -1,16 +1,28 @@
 package com.recipe.jamanchu.service.impl;
 
+import com.recipe.jamanchu.auth.jwt.JwtUtil;
 import com.recipe.jamanchu.component.UserAccessHandler;
+import com.recipe.jamanchu.exceptions.exception.RefreshTokenExpiredException;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
+import com.recipe.jamanchu.model.type.ResultCode;
+import com.recipe.jamanchu.model.type.TokenType;
+import com.recipe.jamanchu.model.type.UserRole;
 import com.recipe.jamanchu.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
   private final UserAccessHandler userAccessHandler;
+  private final JwtUtil jwtUtil;
 
   @Override
   public ResultResponse checkEmail(String email) {
@@ -22,5 +34,30 @@ public class AuthServiceImpl implements AuthService {
   public ResultResponse checkNickname(String nickname) {
 
     return userAccessHandler.existsByNickname(nickname);
+  }
+
+  @Override
+  public ResultResponse refreshToken(HttpServletRequest request, HttpServletResponse response) {
+    Cookie[] cookies = request.getCookies();
+    log.info("cookies.length -> {}", cookies.length);
+
+    String refreshToken =  Arrays.stream(request.getCookies())
+        .filter(cookie -> TokenType.REFRESH.getValue().equals(cookie.getName()))
+        .map(Cookie::getValue)
+        .findFirst()
+        .orElse(null);
+
+    if (refreshToken == null || jwtUtil.isExpired(refreshToken)) {
+      throw new RefreshTokenExpiredException();
+    }
+
+    Long userId = jwtUtil.getUserId(refreshToken);
+    UserRole role = UserRole.valueOf(jwtUtil.getRole(refreshToken));
+
+    String access = jwtUtil.createJwt("access", userId, role);
+
+    response.addHeader(TokenType.ACCESS.getValue(), "Bearer " + access);
+
+    return ResultResponse.of(ResultCode.SUCCESS_REISSUE_REFRESH_TOKEN);
   }
 }

--- a/jamanchu/src/main/resources/application-prod.yml
+++ b/jamanchu/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ spring:
     import: classpath:secret.yml
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/AuthServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/AuthServiceImplTest.java
@@ -3,9 +3,18 @@ package com.recipe.jamanchu.service.impl;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+import com.recipe.jamanchu.auth.jwt.JwtUtil;
 import com.recipe.jamanchu.component.UserAccessHandler;
+import com.recipe.jamanchu.exceptions.exception.CookieNotFoundException;
+import com.recipe.jamanchu.exceptions.exception.RefreshTokenExpiredException;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.model.type.ResultCode;
+import com.recipe.jamanchu.model.type.TokenType;
+import com.recipe.jamanchu.model.type.UserRole;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,8 +28,31 @@ class AuthServiceImplTest {
   @Mock
   private UserAccessHandler userAccessHandler;
 
+  @Mock
+  private JwtUtil jwtUtil;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  private static final Long USERID = 1L;
+  private static final String STR_ROLE = "USER";
+  private static final String TOKEN_TYPE = "access";
+  private static final String REFRESH_TOKEN = "refresh-token";
+  private static final String NEW_ACCESS_TOKEN = "new-access-token";
+
+  private Cookie[] cookies;
+
   @InjectMocks
   private AuthServiceImpl authService;
+
+  @BeforeEach
+  void setUp() {
+    Cookie refreshCookie = new Cookie(TokenType.REFRESH.getValue(), REFRESH_TOKEN);
+    cookies = new Cookie[] {refreshCookie};
+  }
 
   @Test
   @DisplayName("checkEmail : 이미 사용 중인 이메일입니다.")
@@ -82,5 +114,45 @@ class AuthServiceImplTest {
     ResultResponse result = authService.checkNickname(nickname);
 
     assertEquals(resultCode, result);
+  }
+
+  @Test
+  @DisplayName("Access-Token 재발급 성공")
+  void success_Reissue_RefreshToken() {
+    // given
+    when(request.getCookies()).thenReturn(cookies);
+    when(jwtUtil.isExpired(REFRESH_TOKEN)).thenReturn(false);
+    when(jwtUtil.getUserId(REFRESH_TOKEN)).thenReturn(USERID);
+    when(jwtUtil.getRole(REFRESH_TOKEN)).thenReturn(STR_ROLE);
+    when(jwtUtil.createJwt(TOKEN_TYPE, USERID, UserRole.valueOf(STR_ROLE))).thenReturn(NEW_ACCESS_TOKEN);
+
+    // when
+    ResultResponse resultResponse = authService.refreshToken(request, response);
+
+    // then
+    assertEquals(ResultCode.SUCCESS_REISSUE_REFRESH_TOKEN.getStatusCode(), resultResponse.getCode());
+  }
+
+  @Test
+  @DisplayName("Access-Token 재발급 실패 : 쿠키값이 null인 경우")
+  void reissue_RefreshToken_CookieIsNull() {
+    // given
+    when(request.getCookies()).thenReturn(null);
+
+    // when & then
+    assertThrows(CookieNotFoundException.class, () -> authService.refreshToken(request, response));
+
+  }
+
+  @Test
+  @DisplayName("Access-Token 재발급 실패 : refresh 토큰이 만료가 된경우")
+  void reissue_RefreshToken_Expired() {
+    // given
+    when(request.getCookies()).thenReturn(cookies);
+    when(jwtUtil.isExpired(REFRESH_TOKEN)).thenReturn(true);
+
+    // when & then
+    assertThrows(RefreshTokenExpiredException.class, () -> authService.refreshToken(request, response));
+
   }
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- access-token이 만료 시 refresh 토큰을 재 발급 받지 않고 요청을 종료하도록 수정하였습니다.
- /api/v1/auth/token/refresh 요청시 refresh 토큰으로 access-token 재발급 후 반환 할 수 있도록 구현을 하였습니다.


- 구현한 클래스
   - RefreshTokenExpiredException
      - refresh 토큰 만료 예외 처리 클래스
   - CookieNotFoundException
      - 쿠키의 null 값을 처리 하는 예외 처리 클래스

- 수정한 클래스
    - StringSecurity
       - 토큰 재발급 요청 경로 권한 부여  
    - JwtFilter
       - refresh 토큰 재발급 로직 삭제
       - UserDetails 조회 및 Authentication 객체 생성 로직 삭제
    - JwtUtil
       - UserDetails 조회 및 Authentication 객체 생성 로직 구현
       - isExpired(토큰 만료 검증 메서드) 반환 값 boolean으로 변경   
       - getType 메서드 삭제
    - AuthController
       - 토큰 재발급 요청 controller 메서드 구현
    - AuthService & AuthServiceImpl
       - 토큰 재발급 로직 구현
    - ResultCode
       - 재발급 성공 상태 코드 추가  
    - ExceptionStatus
       - 재발급 성공 상태 코드 추가 
          - 프론트 요청으로 상태값을 다르게 설정

- 테스트 클래스  
   - AuthServiceImplTest
      - 토큰 재발급 테스트 코드 구현  

## 스크린샷

## 주의사항

Closes #105 
