### PR TITLE
[feat] 레시피 검색할 때 찜한 레시피 제외하고 리스트 반환

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -29,10 +29,11 @@ public class RecipeController {
 
   @GetMapping
   public ResponseEntity<ResultResponse> getRecipes(
+      HttpServletRequest request,
       @RequestParam(value = "page", defaultValue = "0") int page,
       @RequestParam(value = "size", defaultValue = "15") int size
   ) {
-    return ResponseEntity.ok(recipeService.getRecipes(page, size));
+    return ResponseEntity.ok(recipeService.getRecipes(request, page, size));
   }
 
   @GetMapping("/search")

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -54,10 +54,11 @@ public class RecipeController {
 
   @GetMapping("/popular")
   public ResponseEntity<ResultResponse> getRecipesByRating(
+      HttpServletRequest request,
       @RequestParam(value = "page", defaultValue = "0") int page,
       @RequestParam(value = "size", defaultValue = "15") int size
   ) {
-    return ResponseEntity.ok(recipeService.getRecipesByRating(page, size));
+    return ResponseEntity.ok(recipeService.getRecipesByRating(request, page, size));
   }
 
   @PostMapping

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -38,11 +38,12 @@ public class RecipeController {
 
   @GetMapping("/search")
   public ResponseEntity<ResultResponse> searchRecipes(
+      HttpServletRequest request,
       @Valid @RequestBody RecipesSearchDTO recipesSearchDTO,
       @RequestParam(value = "page", defaultValue = "0") int page,
       @RequestParam(value = "size", defaultValue = "15") int size
   ) {
-    return ResponseEntity.ok(recipeService.searchRecipes(recipesSearchDTO, page, size));
+    return ResponseEntity.ok(recipeService.searchRecipes(request, recipesSearchDTO, page, size));
   }
 
   @GetMapping("/{recipeId}")

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeRepository.java
@@ -56,4 +56,11 @@ public interface RecipeRepository extends JpaRepository<RecipeEntity, Long> {
   Optional<List<RecipeEntity>> findAllByUser(UserEntity user);
 
   Page<RecipeEntity> findByIdNotIn(List<Long> ids, Pageable pageable);
+
+  @Query("SELECT r FROM RecipeEntity r " +
+      "LEFT JOIN r.rating rat " +
+      "WHERE r.id NOT IN :ids " +
+      "GROUP BY r.id " +
+      "ORDER BY AVG(rat.rating) DESC")
+  Page<RecipeEntity> findByIdNotInOrderByRating(@Param("ids") List<Long> ids, Pageable pageable);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeRepository.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RecipeRepository extends JpaRepository<RecipeEntity, Long> {
 
+  // AND 조건으로 검색하는 쿼리
   @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +
       "WHERE (:ingredients IS NULL OR ri.name IN :ingredients) " +
       "AND (:cookingTime IS NULL OR r.time = :cookingTime) " +
@@ -29,6 +30,7 @@ public interface RecipeRepository extends JpaRepository<RecipeEntity, Long> {
       @Param("ingredientCount") Long ingredientCount,
       Pageable pageable);
 
+  // OR 조건으로 검색하는 쿼리
   @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +
       "WHERE (:level IS NULL OR r.level = :level) " +
       "OR (:cookingTime IS NULL OR r.time = :cookingTime) " +
@@ -39,6 +41,7 @@ public interface RecipeRepository extends JpaRepository<RecipeEntity, Long> {
       @Param("ingredients") List<String> ingredients,
       Pageable pageable);
 
+  // 평점순으로 레시피 가져오는 쿼리
   @Query("SELECT r FROM RecipeEntity r " +
       "LEFT JOIN r.rating rat " +
       "GROUP BY r.id " +
@@ -55,12 +58,44 @@ public interface RecipeRepository extends JpaRepository<RecipeEntity, Long> {
 
   Optional<List<RecipeEntity>> findAllByUser(UserEntity user);
 
+  // 찜 레시피에 해당하는 ids(레시피)는 제외하고 모든 레시피 검색하는 쿼리
   Page<RecipeEntity> findByIdNotIn(List<Long> ids, Pageable pageable);
 
+  // 찜 레시피에 해당하는 ids(레시피)는 제외하고 평점순으로 검색하는 쿼리
   @Query("SELECT r FROM RecipeEntity r " +
       "LEFT JOIN r.rating rat " +
       "WHERE r.id NOT IN :ids " +
       "GROUP BY r.id " +
       "ORDER BY AVG(rat.rating) DESC")
   Page<RecipeEntity> findByIdNotInOrderByRating(@Param("ids") List<Long> ids, Pageable pageable);
+
+  // 찜 레시피에 해당하는 ids(레시피)는 제외하고 AND 조건으로 검색하는 쿼리
+  @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +
+      "WHERE (:ingredients IS NULL OR ri.name IN :ingredients) " +
+      "AND (:cookingTime IS NULL OR r.time = :cookingTime) " +
+      "AND (:level IS NULL OR r.level = :level) " +
+      "AND (r.id NOT IN :ids) " +
+      "GROUP BY r.id " +
+      "HAVING COUNT(ri.name) = :ingredientCount")
+  Page<RecipeEntity> searchAndRecipesIdNotIn(@Param("level") LevelType level,
+      @Param("cookingTime") CookingTimeType cookingTime,
+      @Param("ingredients") List<String> ingredients,
+      @Param("ingredientCount") Long ingredientCount,
+      @Param("ids") List<Long> ids,
+      Pageable pageable);
+
+  // 찜 레시피에 해당하는 ids(레시피)는 제외하고 OR 조건으로 검색하는 쿼리
+  @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +
+      "WHERE r.id NOT IN :ids " +  // Apply the exclusion of ids separately
+      "AND (" +  // Start grouping the OR conditions
+      "(:level IS NULL OR r.level = :level) " +
+      "OR (:cookingTime IS NULL OR r.time = :cookingTime) " +
+      "OR (:ingredients IS NULL OR ri.name IN :ingredients)" +
+      ") " +  // End grouping the OR conditions
+      "GROUP BY r.id")
+  Page<RecipeEntity> searchOrRecipesIdNotIn(@Param("level") LevelType level,
+      @Param("cookingTime") CookingTimeType cookingTime,
+      @Param("ingredients") List<String> ingredients,
+      @Param("ids") List<Long> ids,
+      Pageable pageable);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeRepository.java
@@ -54,4 +54,6 @@ public interface RecipeRepository extends JpaRepository<RecipeEntity, Long> {
   Optional<List<RecipeEntity>> findScrapRecipeByUser(UserEntity user, ScrapedType scrapedType);
 
   Optional<List<RecipeEntity>> findAllByUser(UserEntity user);
+
+  Page<RecipeEntity> findByIdNotIn(List<Long> ids, Pageable pageable);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/ScrapedRecipeRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/ScrapedRecipeRepository.java
@@ -3,11 +3,17 @@ package com.recipe.jamanchu.repository;
 import com.recipe.jamanchu.entity.RecipeEntity;
 import com.recipe.jamanchu.entity.ScrapedRecipeEntity;
 import com.recipe.jamanchu.entity.UserEntity;
+import com.recipe.jamanchu.model.type.ScrapedType;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ScrapedRecipeRepository extends JpaRepository<ScrapedRecipeEntity, Long> {
 
   ScrapedRecipeEntity findByUserAndRecipe(UserEntity user, RecipeEntity recipe);
+
+  @Query("SELECT sr.recipe.id FROM ScrapedRecipeEntity sr WHERE sr.user.userId = :userId AND sr.scrapedType = :scrapedType")
+  List<Long> findRecipeIdsByUserIdAndScrapedType(Long userId, ScrapedType scrapedType);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
@@ -25,7 +25,7 @@ public interface RecipeService {
   ResultResponse getRecipeDetail(Long recipesId);
 
   // 인기 레시피 리스트 API
-  ResultResponse getRecipesByRating(int page, int size);
+  ResultResponse getRecipesByRating(HttpServletRequest request, int page, int size);
 
   // 레시피 스크랩 API
   ResultResponse scrapedRecipe(HttpServletRequest request, Long recipeId);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
@@ -16,7 +16,7 @@ public interface RecipeService {
   ResultResponse updateRecipe(HttpServletRequest request, RecipesUpdateDTO recipesUpdateDTO);
 
   // 모든 레시피 조회 API
-  ResultResponse getRecipes(int page, int size);
+  ResultResponse getRecipes(HttpServletRequest request, int page, int size);
 
   // 특정 조건 레시피 조회 API
   ResultResponse searchRecipes(RecipesSearchDTO recipesSearchDTO, int page, int size);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
@@ -19,7 +19,7 @@ public interface RecipeService {
   ResultResponse getRecipes(HttpServletRequest request, int page, int size);
 
   // 특정 조건 레시피 조회 API
-  ResultResponse searchRecipes(RecipesSearchDTO recipesSearchDTO, int page, int size);
+  ResultResponse searchRecipes(HttpServletRequest request, RecipesSearchDTO recipesSearchDTO, int page, int size);
 
   // 레시피 상세 페이지 조회 API
   ResultResponse getRecipeDetail(Long recipesId);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -395,6 +395,8 @@ public class RecipeServiceImpl implements RecipeService {
       }
     } catch (Exception e) {
       // Token이 없거나 유효하지 않은 경우
+      // emptyList() 로 반환
+      return scrapedRecipeIds;
     }
 
     if (userId != null) {

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -386,16 +386,12 @@ public class RecipeServiceImpl implements RecipeService {
 
   // 유저의 scrapedRecipeIds를 가져오는 메서드
   private List<Long> getScrapedRecipeIds(HttpServletRequest request) {
-    Long userId = null;
+    Long userId;
     List<Long> scrapedRecipeIds = Collections.emptyList();
-    try {
-      String token = request.getHeader(TokenType.ACCESS.getValue());
-      if (token != null) {
-        userId = jwtUtil.getUserId(token);
-      }
-    } catch (Exception e) {
-      // Token이 없거나 유효하지 않은 경우
-      // emptyList() 로 반환
+    String token = request.getHeader(TokenType.ACCESS.getValue());
+    if (token != null) {
+      userId = jwtUtil.getUserId(token);
+    } else {
       return scrapedRecipeIds;
     }
 

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -516,7 +516,7 @@ class RecipeServiceImplTest {
     when(recipeRepository.findAllOrderByRating(pageable)).thenReturn(recipePage);
 
     // when
-    ResultResponse result = recipeService.getRecipesByRating(0, 10);
+    ResultResponse result = recipeService.getRecipesByRating(request, 0, 10);
 
     // then
     assertEquals("인기 레시피 조회 성공", result.getMessage());
@@ -543,7 +543,7 @@ class RecipeServiceImplTest {
 
     // when & Then
     assertThrows(RecipeNotFoundException.class,
-        () -> recipeService.getRecipesByRating(page, size));
+        () -> recipeService.getRecipesByRating(request, page, size));
   }
 
   @Test

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -430,7 +430,7 @@ class RecipeServiceImplTest {
         any(Pageable.class))).thenReturn(recipePage);
 
     // when
-    ResultResponse result = recipeService.searchRecipes(searchDTO, 0, 10);
+    ResultResponse result = recipeService.searchRecipes(request, searchDTO, 0, 10);
 
     // then
     assertEquals("레시피 조회 성공!", result.getMessage());
@@ -457,7 +457,7 @@ class RecipeServiceImplTest {
 
     // when & then
     assertThrows(RecipeNotFoundException.class,
-        () -> recipeService.searchRecipes(searchDTO, 0, 10));
+        () -> recipeService.searchRecipes(request, searchDTO, 0, 10));
   }
 
   @Test


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 전체 레시피 조회, 조건 검색 레시피 조회, 평점 레시피 조회를 할 때, 찜한 레시피는 제외하고 나머지 레시피들의 리스트를 보여주는 기능 구현
- 찜한 레시피는 회원만 가지고 있기에, 조회 메서드에 로그인 여부를 판단하는 부분 추가
  - 로그인을 하지 않아서 userId가 없다면, 모든 레시피 리스트 반환
    - token의 여부로 로그인 상태 확인 및 userId 반환
  - 로그인을 했다면 찜 리스트가 있는지 여부를 판단
    - 찜 리스트가 없다면 모든 레시피 리스트 반환
    - 찜 리스트가 있다면 해당 레시피 제외하고 리스트 반환
- **RecipeRepository** 에서 각 레시피 조회할 때, 찜한 레시피 id 리스트(ids)가 있다면 해당 레시피를 제외하고 반환하는 쿼리문 작성
  - **findByIdNotIn**
    - 전체 레시피 조회에서 찜한 레시피 id 리스트(ids)가 있다면 해당 레시피를 제외하고 반환하는 쿼리
  - **findByIdNotInOrderByRating**
    - 평점 레시피 조회에서 찜한 레시피 id 리스트(ids)가 있다면 해당 레시피를 제외하고 반환하는 쿼리
  - **searchAndRecipesIdNotIn**
    - 검색 레시피 조회에서 찜한 레시피 id 리스트(ids)가 있다면 해당 레시피를 제외하고 and 조건으로 반환하는 쿼리
  - **searchOrRecipesIdNotIn** 
    - 검색 레시피 조회에서 찜한 레시피 id 리스트(ids)가 있다면 해당 레시피를 제외하고 or 조건으로 반환하는 쿼리
- **ScrapedRecipeRepository** 에서 찜한 레시피 id 리스트(ids)를 반환하는 쿼리문 작성
  - **findRecipeIdsByUserIdAndScrapedType**
- **RecipeServiceImpl** 에서 각 조회 조건에 아래의 내용 추가
  - 로그인 했는지 여부 확인하는 코드 추가
  - 찜 리스트가 있는지 확인하는 코드 추가
  - 로그인 + 찜 리스트가 있다면 반환하는 수정된 쿼리 동작
  - 로그인을 하지 않았거나 찜 리스트가 없다면 기존(모든 레시피 반환)의 쿼리 동작
- **RecipeServiceImpl** 에서 중복되는 부분을 함수로 빼서 리팩토링
  - **getScrapedRecipeIds**
    - 로그인 여부 확인해서 찜 리스트(ids)를 반환해주는 함수
  - **convertToRecipesSummary**
    - RecipeEntity 리스트를 RecipesSummary 로 변환해주는 메서드
- 조건 검색 메서드 (searchRecipes) 에서 **and 조건 쿼리문** 과 **or 조건 쿼리문**에 대한 부분이 한 눈에 들어오지 않아서 리팩토링 진행
  - and 조건과 or 조건에서 찜한 레시피 id 리스트(ids)의 여부에 따라 동작하는 쿼리 분기 설정
  - **searchAndRecipes**
    - and 조건 함수
  - **searchOrRecipes**
    - or 조건 함수
- 수정된 내용에 따른 테스트 코드 수정 작성

## 스크린샷
- 모든 사항 수정 후 테스트 코드 실행 결과
![스크린샷 2024-10-16 오후 4 03 03](https://github.com/user-attachments/assets/1a3bbf0d-a5ce-4161-9dec-99a7ebe15e4e)

## 주의사항

Closes #99 
