### PR TITLE
[fix] JwtFilter Response CORS 헤더 추가

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -72,6 +72,13 @@ public class JwtFilter extends OncePerRequestFilter {
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
 
+    // CORS 헤더 추가
+    response.setHeader("Access-Control-Allow-Origin", "https://frontend-dun-eight-78.vercel.app");
+    response.setHeader("Access-Control-Allow-Credentials", "true");
+    response.setHeader("Access-Control-Allow-Methods", "GET,HEAD,POST,DELETE,TRACE,OPTIONS,PATCH,PUT");
+    response.setHeader("Access-Control-Allow-Headers", "*");
+    response.setHeader("Access-Control-Expose-Headers", "access-token, Location");
+
     Map<String, String> body = Map.of("message", "access-token 만료");
     response.getWriter().write(objectMapper.writeValueAsString(body));
   }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/auth/jwt/JwtFilter.java
@@ -1,6 +1,7 @@
 package com.recipe.jamanchu.auth.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recipe.jamanchu.model.type.ConstantsType;
 import com.recipe.jamanchu.model.type.TokenType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -73,7 +74,7 @@ public class JwtFilter extends OncePerRequestFilter {
     response.setCharacterEncoding("UTF-8");
 
     // CORS 헤더 추가
-    response.setHeader("Access-Control-Allow-Origin", "https://frontend-dun-eight-78.vercel.app");
+    response.setHeader("Access-Control-Allow-Origin", ConstantsType.WEB_URL);
     response.setHeader("Access-Control-Allow-Credentials", "true");
     response.setHeader("Access-Control-Allow-Methods", "GET,HEAD,POST,DELETE,TRACE,OPTIONS,PATCH,PUT");
     response.setHeader("Access-Control-Allow-Headers", "*");

--- a/jamanchu/src/main/java/com/recipe/jamanchu/config/WebMvcConfig.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package com.recipe.jamanchu.config;
 
+import com.recipe.jamanchu.model.type.ConstantsType;
 import com.recipe.jamanchu.model.type.TokenType;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
@@ -17,9 +18,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     registry.addMapping("/**") // CORS 설정을 모든 URL에 적용
 
-        .allowedOrigins(
-            "https://frontend-dun-eight-78.vercel.app/"
-        )
+        .allowedOrigins(ConstantsType.WEB_URL)
         .allowedMethods(ALLOW_METHOD_NAMES.split(","))  // 허용할 HTTP Method 목록
         .allowedHeaders("*")        // 모든 HTTP header 허용
         .allowCredentials(true)     // 자격 증명 허용

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ConstantsType.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/type/ConstantsType.java
@@ -1,0 +1,5 @@
+package com.recipe.jamanchu.model.type;
+
+public class ConstantsType {
+  public static final String WEB_URL = "https://frontend-dun-eight-78.vercel.app";
+}

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -112,7 +112,7 @@ class UserServiceImplTest {
   @BeforeEach
   void setUp() {
     signup = new SignupDTO(EMAIL, PASSWORD, NICKNAME);
-    userUpdateDTO = new UserUpdateDTO(NEW_NICKNAME, BEFORE_PASSWORD, AFTER_PASSWORD);
+    userUpdateDTO = new UserUpdateDTO(NEW_NICKNAME, PASSWORD);
     deleteUserDTO = new DeleteUserDTO(PASSWORD);
     userInfoDTO = new UserInfoDTO(EMAIL, NICKNAME);
     loginDTO = new LoginDTO(EMAIL, PASSWORD);


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
발생한 문제

클라이언트가 만료된 토큰을 사용해 서버에 요청을 보내면, JwtFilter에서 해당 요청을 중단하고,
“토큰이 만료되었다”는 응답을 만들어 클라이언트에 전달 합니다. 
하지만 응답을 클라이언트에 전달하는 과정에서 CORS 에러가 발생했습니다.

문제 원인

직접 구현한 WebMvcConfig 설정을 통해 Spring에서 자동으로 CORS 헤더를 추가합니다.
하지만 Spring이 자동으로 추가하는 CORS 헤더가 JwtFilter에서는 동작하지 않아, 클라이언트로 응답 전달시 CORS 헤더가 존재하지 않기   때문에 CORS 에러가 발생했습니다.

해결방법

JwtFilter의 setResponse() 메서드에서, 응답을 생성할 때 CORS 헤더를 추가했습니다. 
이렇게 하면 Spring의 CORS 자동 처리가 생략된 상황에서도, JwtFilter에서 응답을 생성할 때 클라이언트가 CORS 응답을 받을 수 있습니다.

UserServiceImplTest 코드에 놓친 부분이 있어, 발생했던 오류를 수정하였습니다.

## 스크린샷

## 주의사항

Closes #117 
