### PR TITLE
[fix] 레시피 삭제 로직 이슈 수정

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/IngredientEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/IngredientEntity.java
@@ -26,6 +26,6 @@ public class IngredientEntity {
   private Long ingredientId;
 
   @NotNull
-  @Column(name = "ing_name")
+  @Column(name = "ing_name", unique = true)
   private String ingredientName;
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/IngredientEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/IngredientEntity.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -19,7 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name = "rcp_ing")
+@Table(name = "ing")
 public class IngredientEntity {
 
   @Id
@@ -28,14 +26,6 @@ public class IngredientEntity {
   private Long ingredientId;
 
   @NotNull
-  @ManyToOne
-  @JoinColumn(name = "rcp_id")
-  private RecipeEntity recipe;
-
-  @NotNull
-  @Column(name = "ing_name", length = 30)
-  private String name;
-
-  @Column(name = "quantity")
-  private String quantity;
+  @Column(name = "ing_name")
+  private String ingredientName;
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeEntity.java
@@ -69,7 +69,7 @@ public class RecipeEntity extends BaseTimeEntity{
   private List<ManualEntity> manuals;
 
   @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-  private List<IngredientEntity> ingredients;
+  private List<RecipeIngredientEntity> ingredients;
 
   @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
   private List<RecipeRatingEntity> rating;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeIngredientEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeIngredientEntity.java
@@ -1,0 +1,41 @@
+package com.recipe.jamanchu.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "rcp_ing")
+public class RecipeIngredientEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "ri_id")
+  private Long ingredientId;
+
+  @NotNull
+  @ManyToOne
+  @JoinColumn(name = "rcp_id")
+  private RecipeEntity recipe;
+
+  @NotNull
+  @Column(name = "ing_name", length = 30)
+  private String name;
+
+  @Column(name = "quantity")
+  private String quantity;
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/IngredientRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/IngredientRepository.java
@@ -1,18 +1,12 @@
 package com.recipe.jamanchu.repository;
 
 import com.recipe.jamanchu.entity.IngredientEntity;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface IngredientRepository extends JpaRepository<IngredientEntity, Long> {
 
-  @Modifying
-  @Query("DELETE FROM IngredientEntity i WHERE i.recipe.id = :recipeId")
-  void deleteAllByRecipeId(@Param("recipeId") Long recipeId);
+  Optional<IngredientEntity> findByIngredientName(String ingredientName);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeIngredientRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/RecipeIngredientRepository.java
@@ -1,8 +1,6 @@
 package com.recipe.jamanchu.repository;
 
-import com.recipe.jamanchu.entity.ManualEntity;
-import java.util.List;
-import java.util.Optional;
+import com.recipe.jamanchu.entity.RecipeIngredientEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -10,9 +8,9 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ManualRepository extends JpaRepository<ManualEntity, Long> {
+public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredientEntity, Long> {
 
   @Modifying
-  @Query("DELETE FROM ManualEntity m WHERE m.recipe.id = :recipeId")
+  @Query("DELETE FROM RecipeIngredientEntity i WHERE i.recipe.id = :recipeId")
   void deleteAllByRecipeId(@Param("recipeId") Long recipeId);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -5,6 +5,7 @@ import static com.recipe.jamanchu.model.type.RecipeProvider.*;
 import com.recipe.jamanchu.auth.jwt.JwtUtil;
 import com.recipe.jamanchu.component.UserAccessHandler;
 import com.recipe.jamanchu.entity.IngredientEntity;
+import com.recipe.jamanchu.entity.RecipeIngredientEntity;
 import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.entity.RecipeEntity;
 import com.recipe.jamanchu.entity.RecipeIngredientMappingEntity;
@@ -27,6 +28,7 @@ import com.recipe.jamanchu.model.type.TokenType;
 import com.recipe.jamanchu.repository.IngredientRepository;
 import com.recipe.jamanchu.repository.ManualRepository;
 import com.recipe.jamanchu.repository.RecipeIngredientMappingRepository;
+import com.recipe.jamanchu.repository.RecipeIngredientRepository;
 import com.recipe.jamanchu.repository.RecipeRatingRepository;
 import com.recipe.jamanchu.repository.RecipeRepository;
 import com.recipe.jamanchu.repository.ScrapedRecipeRepository;
@@ -50,11 +52,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class RecipeServiceImpl implements RecipeService {
 
   private final RecipeRepository recipeRepository;
-  private final IngredientRepository ingredientRepository;
+  private final RecipeIngredientRepository recipeIngredientRepository;
   private final ManualRepository manualRepository;
   private final ScrapedRecipeRepository scrapedRecipeRepository;
   private final RecipeRatingRepository recipeRatingRepository;
   private final RecipeIngredientMappingRepository recipeIngredientMappingRepository;
+  private final IngredientRepository ingredientRepository;
   private final UserAccessHandler userAccessHandler;
   private final JwtUtil jwtUtil;
 
@@ -76,21 +79,34 @@ public class RecipeServiceImpl implements RecipeService {
 
     recipeRepository.save(recipe);
 
-    List<IngredientEntity> ingredients = new ArrayList<>();
+    List<RecipeIngredientEntity> recipeIngredientEntities = new ArrayList<>();
     for (int i = 0; i < recipesDTO.getRecipeIngredients().size(); i++) {
-      IngredientEntity ingredient = IngredientEntity.builder()
+      RecipeIngredientEntity ingredient = RecipeIngredientEntity.builder()
           .recipe(recipe)
           .name(recipesDTO.getRecipeIngredients().get(i).getIngredientName())
           .quantity(recipesDTO.getRecipeIngredients().get(i).getIngredientQuantity())
           .build();
 
-      ingredients.add(ingredient);
+      recipeIngredientEntities.add(ingredient);
     }
 
-    ingredientRepository.saveAll(ingredients);
+    recipeIngredientRepository.saveAll(recipeIngredientEntities);
 
+    List<IngredientEntity> ingredientEntities = new ArrayList<>();
     List<RecipeIngredientMappingEntity> recipeIngredientMappings = new ArrayList<>();
-    for (IngredientEntity ingredient : ingredients) {
+    for (RecipeIngredientEntity recipeIngredient : recipeIngredientEntities) {
+      Optional<IngredientEntity> existingIngredient = ingredientRepository.findByIngredientName(recipeIngredient.getName());
+
+      IngredientEntity ingredient;
+      if (existingIngredient.isPresent()) {
+        ingredient = existingIngredient.get();
+      } else {
+        ingredient = IngredientEntity.builder()
+            .ingredientName(recipeIngredient.getName())
+            .build();
+        ingredientEntities.add(ingredient);
+      }
+
       RecipeIngredientMappingEntity mapping = RecipeIngredientMappingEntity.builder()
           .recipe(recipe)
           .ingredient(ingredient)
@@ -99,6 +115,7 @@ public class RecipeServiceImpl implements RecipeService {
       recipeIngredientMappings.add(mapping);
     }
 
+    ingredientRepository.saveAll(ingredientEntities);
     recipeIngredientMappingRepository.saveAll(recipeIngredientMappings);
 
     List<ManualEntity> manuals = new ArrayList<>();
@@ -140,23 +157,36 @@ public class RecipeServiceImpl implements RecipeService {
 
     // 기존 recipeId로 저장된 재료 삭제
     recipeIngredientMappingRepository.deleteAllByRecipeId(recipeId);
-    ingredientRepository.deleteAllByRecipeId(recipeId);
+    recipeIngredientRepository.deleteAllByRecipeId(recipeId);
 
-    List<IngredientEntity> ingredients = new ArrayList<>();
+    List<RecipeIngredientEntity> recipeIngredientEntities = new ArrayList<>();
     for (int i = 0; i < recipesUpdateDTO.getRecipeIngredients().size(); i++) {
-      IngredientEntity ingredient = IngredientEntity.builder()
+      RecipeIngredientEntity ingredient = RecipeIngredientEntity.builder()
           .recipe(recipe)
           .name(recipesUpdateDTO.getRecipeIngredients().get(i).getIngredientName())
           .quantity(recipesUpdateDTO.getRecipeIngredients().get(i).getIngredientQuantity())
           .build();
 
-      ingredients.add(ingredient);
+      recipeIngredientEntities.add(ingredient);
     }
 
-    ingredientRepository.saveAll(ingredients);
+    recipeIngredientRepository.saveAll(recipeIngredientEntities);
 
+    List<IngredientEntity> ingredientEntities = new ArrayList<>();
     List<RecipeIngredientMappingEntity> recipeIngredientMappings = new ArrayList<>();
-    for (IngredientEntity ingredient : ingredients) {
+    for (RecipeIngredientEntity recipeIngredient : recipeIngredientEntities) {
+      Optional<IngredientEntity> existingIngredient = ingredientRepository.findByIngredientName(recipeIngredient.getName());
+
+      IngredientEntity ingredient;
+      if (existingIngredient.isPresent()) {
+        ingredient = existingIngredient.get();
+      } else {
+        ingredient = IngredientEntity.builder()
+            .ingredientName(recipeIngredient.getName())
+            .build();
+        ingredientEntities.add(ingredient);
+      }
+
       RecipeIngredientMappingEntity mapping = RecipeIngredientMappingEntity.builder()
           .recipe(recipe)
           .ingredient(ingredient)
@@ -165,6 +195,7 @@ public class RecipeServiceImpl implements RecipeService {
       recipeIngredientMappings.add(mapping);
     }
 
+    ingredientRepository.saveAll(ingredientEntities);
     recipeIngredientMappingRepository.saveAll(recipeIngredientMappings);
 
     manualRepository.deleteAllByRecipeId(recipeId);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -95,17 +95,14 @@ public class RecipeServiceImpl implements RecipeService {
     List<IngredientEntity> ingredientEntities = new ArrayList<>();
     List<RecipeIngredientMappingEntity> recipeIngredientMappings = new ArrayList<>();
     for (RecipeIngredientEntity recipeIngredient : recipeIngredientEntities) {
-      Optional<IngredientEntity> existingIngredient = ingredientRepository.findByIngredientName(recipeIngredient.getName());
-
-      IngredientEntity ingredient;
-      if (existingIngredient.isPresent()) {
-        ingredient = existingIngredient.get();
-      } else {
-        ingredient = IngredientEntity.builder()
-            .ingredientName(recipeIngredient.getName())
-            .build();
-        ingredientEntities.add(ingredient);
-      }
+      IngredientEntity ingredient = ingredientRepository.findByIngredientName(recipeIngredient.getName())
+          .orElseGet(() -> {
+            IngredientEntity newIngredient = IngredientEntity.builder()
+                .ingredientName(recipeIngredient.getName())
+                .build();
+            ingredientEntities.add(newIngredient);
+            return newIngredient;
+          });
 
       RecipeIngredientMappingEntity mapping = RecipeIngredientMappingEntity.builder()
           .recipe(recipe)
@@ -175,17 +172,14 @@ public class RecipeServiceImpl implements RecipeService {
     List<IngredientEntity> ingredientEntities = new ArrayList<>();
     List<RecipeIngredientMappingEntity> recipeIngredientMappings = new ArrayList<>();
     for (RecipeIngredientEntity recipeIngredient : recipeIngredientEntities) {
-      Optional<IngredientEntity> existingIngredient = ingredientRepository.findByIngredientName(recipeIngredient.getName());
-
-      IngredientEntity ingredient;
-      if (existingIngredient.isPresent()) {
-        ingredient = existingIngredient.get();
-      } else {
-        ingredient = IngredientEntity.builder()
-            .ingredientName(recipeIngredient.getName())
-            .build();
-        ingredientEntities.add(ingredient);
-      }
+      IngredientEntity ingredient = ingredientRepository.findByIngredientName(recipeIngredient.getName())
+          .orElseGet(() -> {
+            IngredientEntity newIngredient = IngredientEntity.builder()
+                .ingredientName(recipeIngredient.getName())
+                .build();
+            ingredientEntities.add(newIngredient);
+            return newIngredient;
+          });
 
       RecipeIngredientMappingEntity mapping = RecipeIngredientMappingEntity.builder()
           .recipe(recipe)

--- a/jamanchu/src/test/java/com/recipe/jamanchu/entity/IngredientEntityTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/entity/IngredientEntityTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.recipe.jamanchu.repository.IngredientRepository;
+import jakarta.persistence.criteria.CriteriaBuilder.In;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,18 +19,12 @@ class IngredientEntityTest {
   private IngredientRepository ingredientRepository;
 
   @Test
-  @DisplayName("Ingredient Entity Builder Test")
+  @DisplayName("Ingredient Entity Builder test")
   void builder() {
-
     // given
-    RecipeEntity recipe = RecipeEntity.builder()
-        .id(1L)
-        .build();
-
     IngredientEntity ingredientEntity = IngredientEntity.builder()
-        .recipe(recipe)
-        .name("양배추")
-        .quantity("1/2개")
+        .ingredientId(1L)
+        .ingredientName("양배추")
         .build();
 
     // when
@@ -39,8 +34,8 @@ class IngredientEntityTest {
     IngredientEntity savedIngredient = ingredientRepository.save(ingredientEntity);
 
     // then
-    assertEquals(ingredientEntity.getRecipe().getId(), savedIngredient.getRecipe().getId());
-    assertEquals(ingredientEntity.getName(), savedIngredient.getName());
-    assertEquals(ingredientEntity.getQuantity(), savedIngredient.getQuantity());
+    assertEquals(ingredientEntity.getIngredientId(), savedIngredient.getIngredientId());
+    assertEquals(ingredientEntity.getIngredientName(), savedIngredient.getIngredientName());
   }
+
 }

--- a/jamanchu/src/test/java/com/recipe/jamanchu/entity/IngredientRatingEntityTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/entity/IngredientRatingEntityTest.java
@@ -32,7 +32,7 @@ class IngredientRatingEntityTest {
 
     IngredientEntity ingredient = IngredientEntity.builder()
         .ingredientId(1L)
-        .name("ingredient")
+        .ingredientName("ingredient")
         .build();
 
     IngredientRatingEntity ingredientRatingEntity = IngredientRatingEntity.builder()

--- a/jamanchu/src/test/java/com/recipe/jamanchu/entity/RecipeIngredientEntityTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/entity/RecipeIngredientEntityTest.java
@@ -1,0 +1,47 @@
+package com.recipe.jamanchu.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.recipe.jamanchu.repository.IngredientRepository;
+import com.recipe.jamanchu.repository.RecipeIngredientRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecipeIngredientEntityTest {
+
+  @Mock
+  private RecipeIngredientRepository recipeIngredientRepository;
+
+  @Test
+  @DisplayName("RecipeIngredient Entity Builder Test")
+  void builder() {
+
+    // given
+    RecipeEntity recipe = RecipeEntity.builder()
+        .id(1L)
+        .build();
+
+    RecipeIngredientEntity recipeIngredientEntity = RecipeIngredientEntity.builder()
+        .recipe(recipe)
+        .name("양배추")
+        .quantity("1/2개")
+        .build();
+
+    // when
+    when(recipeIngredientRepository.save(any())).thenReturn(recipeIngredientEntity);
+
+    // Act
+    RecipeIngredientEntity savedIngredient = recipeIngredientRepository.save(recipeIngredientEntity);
+
+    // then
+    assertEquals(recipeIngredientEntity.getRecipe().getId(), savedIngredient.getRecipe().getId());
+    assertEquals(recipeIngredientEntity.getName(), savedIngredient.getName());
+    assertEquals(recipeIngredientEntity.getQuantity(), savedIngredient.getQuantity());
+  }
+}

--- a/jamanchu/src/test/java/com/recipe/jamanchu/entity/RecipeIngredientMappingEntityTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/entity/RecipeIngredientMappingEntityTest.java
@@ -27,7 +27,7 @@ class RecipeIngredientMappingEntityTest {
 
     IngredientEntity ingredient = IngredientEntity.builder()
         .ingredientId(1L)
-        .name("ingredient")
+        .ingredientName("ingredient")
         .build();
 
     RecipeIngredientMappingEntity recipeIngredientMappingEntity = RecipeIngredientMappingEntity.builder()

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeDivideServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeDivideServiceImplTest.java
@@ -2,7 +2,6 @@ package com.recipe.jamanchu.service.impl;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.times;
@@ -10,9 +9,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.recipe.jamanchu.component.UserAccessHandler;
-import com.recipe.jamanchu.entity.IngredientEntity;
 import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.entity.RecipeEntity;
+import com.recipe.jamanchu.entity.RecipeIngredientEntity;
 import com.recipe.jamanchu.entity.RecipeRatingEntity;
 import com.recipe.jamanchu.entity.TenThousandRecipeEntity;
 import com.recipe.jamanchu.entity.UserEntity;
@@ -24,6 +23,7 @@ import com.recipe.jamanchu.model.type.UserRole;
 import com.recipe.jamanchu.repository.IngredientRepository;
 import com.recipe.jamanchu.repository.ManualRepository;
 import com.recipe.jamanchu.repository.RecipeIngredientMappingRepository;
+import com.recipe.jamanchu.repository.RecipeIngredientRepository;
 import com.recipe.jamanchu.repository.RecipeRatingRepository;
 import com.recipe.jamanchu.repository.RecipeRepository;
 import com.recipe.jamanchu.repository.TenThousandRecipeRepository;
@@ -54,10 +54,13 @@ class RecipeDivideServiceImplTest {
   private RecipeRatingRepository recipeRatingRepository;
 
   @Mock
+  private IngredientRepository ingredientRepository;
+
+  @Mock
   private ManualRepository manualRepository;
 
   @Mock
-  private IngredientRepository ingredientRepository;
+  private RecipeIngredientRepository recipeIngredientRepository;
 
   @Mock
   private TenThousandRecipeRepository tenThousandRecipeRepository;
@@ -124,7 +127,7 @@ class RecipeDivideServiceImplTest {
     verify(recipeRepository, times(1)).save(any(RecipeEntity.class));
     verify(recipeRatingRepository, times(1)).save(any(RecipeRatingEntity.class));
     verify(manualRepository, times(1)).saveAll(anyList()); // 2개의 매뉴얼 단계가 있음
-    verify(ingredientRepository, times(1)).saveAll(anyList());
+    verify(recipeIngredientRepository, times(1)).saveAll(anyList());
     verify(recipeIngredientMappingRepository, times(1)).saveAll(anyList());
   }
 
@@ -411,7 +414,7 @@ class RecipeDivideServiceImplTest {
     assertEquals("ingredient1 100g,ingredient2 200ml", scrapRecipe.getIngredients());
 
     // verify
-    verify(ingredientRepository, times(1)).saveAll(anyList());
+    verify(recipeIngredientRepository, times(1)).saveAll(anyList());
     verify(recipeIngredientMappingRepository, times(1)).saveAll(anyList());  }
 
   @Test
@@ -432,10 +435,10 @@ class RecipeDivideServiceImplTest {
     recipeDivideService.saveIngredientDetails(recipe, scrapedRecipe);
 
     // then
-    ArgumentCaptor<List<IngredientEntity>> ingredientCaptor = ArgumentCaptor.forClass((Class) List.class);
-    verify(ingredientRepository, times(1)).saveAll(ingredientCaptor.capture());
+    ArgumentCaptor<List<RecipeIngredientEntity>> ingredientCaptor = ArgumentCaptor.forClass((Class) List.class);
+    verify(recipeIngredientRepository, times(1)).saveAll(ingredientCaptor.capture());
 
-    List<IngredientEntity> savedIngredients = ingredientCaptor.getValue();
+    List<RecipeIngredientEntity> savedIngredients = ingredientCaptor.getValue();
 
     // Tomato와 Onion이 올바르게 저장되었는지 확인
     assertEquals(2, savedIngredients.size());
@@ -463,10 +466,10 @@ class RecipeDivideServiceImplTest {
     recipeDivideService.saveIngredientDetails(recipe, scrapedRecipe);
 
     // then
-    ArgumentCaptor<List<IngredientEntity>> ingredientCaptor = ArgumentCaptor.forClass((Class) List.class);
-    verify(ingredientRepository, times(1)).saveAll(ingredientCaptor.capture());
+    ArgumentCaptor<List<RecipeIngredientEntity>> ingredientCaptor = ArgumentCaptor.forClass((Class) List.class);
+    verify(recipeIngredientRepository, times(1)).saveAll(ingredientCaptor.capture());
 
-    List<IngredientEntity> savedIngredients = ingredientCaptor.getValue();
+    List<RecipeIngredientEntity> savedIngredients = ingredientCaptor.getValue();
 
     assertEquals(3, savedIngredients.size());
     assertEquals("Tomato", savedIngredients.get(0).getName());

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeDivideServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeDivideServiceImplTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.recipe.jamanchu.component.UserAccessHandler;
+import com.recipe.jamanchu.entity.IngredientEntity;
 import com.recipe.jamanchu.entity.ManualEntity;
 import com.recipe.jamanchu.entity.RecipeEntity;
 import com.recipe.jamanchu.entity.RecipeIngredientEntity;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -406,6 +408,14 @@ class RecipeDivideServiceImplTest {
   void testSaveIngredientDetails() {
     // given
     RecipeEntity recipe = RecipeEntity.builder().build();
+    IngredientEntity existingIngredient = IngredientEntity.builder()
+        .ingredientId(1L)
+        .ingredientName("ingredient1")
+        .build();
+    when(ingredientRepository.findByIngredientName("ingredient1")).thenReturn(Optional.of(existingIngredient));
+
+    // 새로운 재료가 추가될 경우
+    when(ingredientRepository.findByIngredientName("ingredient2")).thenReturn(Optional.empty());
 
     // when
     recipeDivideService.saveIngredientDetails(recipe, scrapRecipe);
@@ -415,7 +425,11 @@ class RecipeDivideServiceImplTest {
 
     // verify
     verify(recipeIngredientRepository, times(1)).saveAll(anyList());
-    verify(recipeIngredientMappingRepository, times(1)).saveAll(anyList());  }
+    verify(recipeIngredientMappingRepository, times(1)).saveAll(anyList());
+    verify(ingredientRepository, times(1)).findByIngredientName("ingredient1"); // 기존 재료 조회 확인
+    verify(ingredientRepository, times(1)).findByIngredientName("ingredient2"); // 새로운 재료 조회 확인
+    verify(ingredientRepository, times(1)).saveAll(anyList()); // 새로운 재료 저장 확인
+  }
 
   @Test
   @DisplayName("비어있는 재료 항목은 무시하고 다른 재료는 저장")


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- Entity의 미스 매핑으로 인한 레시피 데이터 삭제 시 오류 발생
  - ERD 기준 Entity 이름으로 설명
  - 이슈 상황 : Recipe Entity, RecipeIngredient Entity 매핑, Ingredient Entity 가 없었음.
    - 이로 인해 레시피 삭제 시 에러 발생 #121 
  - 수정 상황 : Recipe Entity, Ingredient Entity 매핑
    - 레시피 등록, 수정, 삭제 테스트 완료

- 위의 내용 수정으로 인한 변경 사항
  - Entity 수정 및 생성
    - Ingredient Entity 용도 변경
    - RecipeIngredient Entity 생성 (기존의 Ingredient Entity)
    - Recipe Entity 수정
      - List<Ingredients> -> List<RecipeIngredients>
  - Repository 수정 및 생성
    - Ingredient Repository 용도 변경
    - RecipeIngredient Repository 생성 (기존의 Ingredient Repository)
    - Manual Repository 수정 (사용하지 않는 함수 제거)
  - Service 메서드에서 레시피 등록 및 수정 시 Ingredient Entity에 존재여부 확인 후 없다면 추가해주는 로직 구현
    - RecipeServiceImpl
      - registerRecipe
      - updateRecipe
    - RecipeDivideServiceImpl
      - saveIngredientDetails
  - Test
    - 위의 변경사항 수정에 따른 테스트 코드 수정 및 추가

## 스크린샷
- RecipeServiceImpl (registerRecipe, updateRecipe)
![스크린샷 2024-10-18 오후 3 29 39](https://github.com/user-attachments/assets/43c1ec1f-7b0e-4a0c-bdd4-3d604a826fc5)
- RecipeDivideServiceImpl
![스크린샷 2024-10-18 오후 3 28 55](https://github.com/user-attachments/assets/b56703f1-c9e0-41bd-a2fd-2ad95c6c38be)

## 주의사항

Closes #121 
