### PR TITLE
[feat] 회원 가입 전 이메일 검증 API 수정

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/component/UserAccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/component/UserAccessHandler.java
@@ -5,6 +5,7 @@ import com.recipe.jamanchu.entity.UserEntity;
 import com.recipe.jamanchu.exceptions.exception.PasswordMismatchException;
 import com.recipe.jamanchu.exceptions.exception.SocialAccountException;
 import com.recipe.jamanchu.exceptions.exception.UserNotFoundException;
+import com.recipe.jamanchu.exceptions.exception.WithdrewUserException;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.model.type.ResultCode;
 import com.recipe.jamanchu.model.type.UserRole;
@@ -16,6 +17,7 @@ import com.recipe.jamanchu.repository.ScrapedRecipeRepository;
 import com.recipe.jamanchu.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -78,13 +80,23 @@ public class UserAccessHandler {
 
   // 이메일 중복 체크
   public ResultResponse existsByEmail(String email){
-
     if (userRepository.existsByEmail(email)) {
+      Optional<UserEntity> userOpt = userRepository.findByEmail(email);
+
+      // 탈퇴한 사용자의 이메일인 경우
+      userOpt.filter(user -> user.getDeletionScheduledAt() != null)
+          .ifPresent(user -> {
+            throw new WithdrewUserException();
+          });
+
+      // 이미 사용중인 이메일
       return ResultResponse.of(ResultCode.EMAIL_ALREADY_IN_USE, false);
     }
 
+    // 사용가능 한 이메일
     return ResultResponse.of(ResultCode.EMAIL_AVAILABLE, true);
   }
+
 
   // 닉네임 중복 체크
   public ResultResponse existsByNickname(String nickname){

--- a/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/ExceptionStatus.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/ExceptionStatus.java
@@ -20,6 +20,8 @@ public enum ExceptionStatus {
   MISSING_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임을 입력해주세요!"),
   REFRESH_TOKEN_EXPIRED(HttpStatus.GONE, "다시 로그인을 해주세요!"),
   COOKIE_NOT_FOUND(HttpStatus.NOT_FOUND, "다시 로그인을 해주세요!"),
+  WITHDREW_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다. 계정 복구를 희망하시면 "
+      + "'user@example.com'으로 문의를 해주세요"),
   ;
 
   private final HttpStatus statusCode;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/exception/WithdrewUserException.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/exceptions/exception/WithdrewUserException.java
@@ -1,0 +1,10 @@
+package com.recipe.jamanchu.exceptions.exception;
+
+import com.recipe.jamanchu.exceptions.ExceptionStatus;
+
+public class WithdrewUserException extends GlobalException {
+
+  public WithdrewUserException() {
+    super(ExceptionStatus.WITHDREW_USER);
+  }
+}

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -188,10 +188,10 @@ class UserServiceImplTest {
   void signup_Success() {
 
     // when
-    ResultCode result = userServiceimpl.signup(signup);
+    ResultResponse result = userServiceimpl.signup(signup);
 
     // then
-    assertEquals(ResultCode.SUCCESS_SIGNUP, result);
+    assertEquals(ResultCode.SUCCESS_SIGNUP.getStatusCode(), result.getCode());
   }
 
   @Test
@@ -290,10 +290,10 @@ class UserServiceImplTest {
     doNothing().when(userAccessHandler).isSocialUser(user.getProvider());
 
     // when
-    ResultCode result = userServiceimpl.updateUserInfo(request, userUpdateDTO);
+    ResultResponse result = userServiceimpl.updateUserInfo(request, userUpdateDTO);
 
     // then
-    assertEquals(ResultCode.SUCCESS_UPDATE_USER_INFO, result);
+    assertEquals(ResultCode.SUCCESS_UPDATE_USER_INFO.getStatusCode(), result.getCode());
   }
 
   @Test
@@ -331,10 +331,10 @@ class UserServiceImplTest {
     when(userAccessHandler.findByUserId(USERID)).thenReturn(user);
 
     // when
-    ResultCode result = userServiceimpl.deleteUser(request);
+    ResultResponse result = userServiceimpl.deleteUser(request);
 
     // then
-    assertEquals(ResultCode.SUCCESS_DELETE_USER, result);
+    assertEquals(ResultCode.SUCCESS_DELETE_USER.getStatusCode(), result.getCode());
   }
 
   @Test
@@ -346,10 +346,10 @@ class UserServiceImplTest {
     when(userAccessHandler.findByUserId(USERID)).thenReturn(kakaoUser);
 
     // when
-    ResultCode result = userServiceimpl.deleteUser(request);
+    ResultResponse result = userServiceimpl.deleteUser(request);
 
     // then
-    assertEquals(ResultCode.SUCCESS_DELETE_USER, result);
+    assertEquals(ResultCode.SUCCESS_DELETE_USER.getStatusCode(), result.getCode());
   }
 
   @Test


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
회원 가입 전 이메일 검증시 탈퇴한 사용자의 이메일 여부도 같이 검증 할 수 있도록 로직을 수정하였습니다.

- 구현한 클래스
   - WithdrewUserException
      - 회원 가입 전 이메일 검증시 해당 이메일이 탈퇴한 회원의 이메일일 경우 예외 처리하는 클래스

-  수정한 클래스
   - ExceptionStatus
      - WithdrewUserException 클래스에서 사용할 상태 코드 추가
   - UserAccessHandler
      - existsByEmail() 
         - 탈퇴한 회원의 이메일 여부를 검증하는 로직 추가 
         - 이미 탈퇴한 회원일 경우 WithdrewUserException처리  

## 스크린샷

## 주의사항

Closes #120 
