### PR TITLE
[feat] 레시피 등록 / 수정 시 S3 연동

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/PictureController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/PictureController.java
@@ -33,7 +33,7 @@ public class PictureController {
   @PostMapping(path = "/orderImages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<List<String>> uploadOrderImages(
       HttpServletRequest request,
-      @RequestPart(value = "recipeOrderImages")List<MultipartFile> recipeOrderImages,
+      @RequestPart(value = "recipeOrderImages", required = false) List<MultipartFile> recipeOrderImages,
       @RequestParam(value = "recipeName") String recipeName
   ) throws IOException {
     return ResponseEntity.ok(pictureService.uploadOrderImages(request, recipeName, recipeOrderImages));

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/PictureController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/PictureController.java
@@ -1,0 +1,42 @@
+package com.recipe.jamanchu.controller;
+
+import com.recipe.jamanchu.service.PictureService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/pictures")
+public class PictureController {
+
+  private final PictureService pictureService;
+
+  @PostMapping(path = "/thumbnail", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<String> uploadThumbnail(
+      HttpServletRequest request,
+      @RequestPart(value = "recipeThumbnail") MultipartFile recipeThumbnail,
+      @RequestParam(value = "recipeName") String recipeName
+  ) throws IOException {
+    return ResponseEntity.ok(pictureService.uploadThumbnail(request, recipeName, recipeThumbnail));
+  }
+
+  @PostMapping(path = "/orderImages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<List<String>> uploadOrderImages(
+      HttpServletRequest request,
+      @RequestPart(value = "recipeOrderImages")List<MultipartFile> recipeOrderImages,
+      @RequestParam(value = "recipeName") String recipeName
+  ) throws IOException {
+    return ResponseEntity.ok(pictureService.uploadOrderImages(request, recipeName, recipeOrderImages));
+  }
+
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -34,7 +34,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class RecipeController {
 
   private final RecipeService recipeService;
-  private final PictureService pictureService;
 
   @GetMapping
   public ResponseEntity<ResultResponse> getRecipes(
@@ -72,24 +71,6 @@ public class RecipeController {
       @RequestParam(value = "size", defaultValue = "15") int size
   ) {
     return ResponseEntity.ok(recipeService.getRecipesByRating(request, page, size));
-  }
-
-  @PostMapping(path = "/upload-thumbnail", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<String> uploadThumbnail(
-      HttpServletRequest request,
-      @RequestPart(value = "recipeThumbnail") MultipartFile recipeThumbnail,
-      @RequestParam(value = "recipeName") String recipeName
-  ) throws IOException {
-    return ResponseEntity.ok(pictureService.uploadThumbnail(request, recipeName, recipeThumbnail));
-  }
-
-  @PostMapping(path = "/upload-orderImages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<List<String>> uploadOrderImages(
-      HttpServletRequest request,
-      @RequestPart(value = "recipeOrderImages")List<MultipartFile> recipeOrderImages,
-      @RequestParam(value = "recipeName") String recipeName
-  ) throws IOException {
-    return ResponseEntity.ok(pictureService.uploadOrderImages(request, recipeName, recipeOrderImages));
   }
 
   @PostMapping

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -73,7 +73,7 @@ public class RecipeController {
       HttpServletRequest request,
       @Valid @RequestBody RecipesDTO recipesDTO,
       @RequestParam("thumbnailUrl") String thumbnailUrl,
-      @RequestParam("recipeOrderImagesUrl") List<String> recipeOrderImagesUrl) {
+      @RequestParam(value = "recipeOrderImagesUrl", required = false) List<String> recipeOrderImagesUrl) {
 
     // 레시피 등록 서비스 호출
     return ResponseEntity.ok(recipeService.registerRecipe(request, recipesDTO, thumbnailUrl, recipeOrderImagesUrl));

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -10,8 +10,11 @@ import com.recipe.jamanchu.model.type.LevelType;
 import com.recipe.jamanchu.service.RecipeService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import com.recipe.jamanchu.service.PictureService;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,7 +24,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecipeController {
 
   private final RecipeService recipeService;
+  private final PictureService pictureService;
 
   @GetMapping
   public ResponseEntity<ResultResponse> getRecipes(
@@ -68,11 +74,33 @@ public class RecipeController {
     return ResponseEntity.ok(recipeService.getRecipesByRating(request, page, size));
   }
 
+  @PostMapping(path = "/upload-thumbnail", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<String> uploadThumbnail(
+      HttpServletRequest request,
+      @RequestPart(value = "recipeThumbnail") MultipartFile recipeThumbnail,
+      @RequestParam(value = "recipeName") String recipeName
+  ) throws IOException {
+    return ResponseEntity.ok(pictureService.uploadThumbnail(request, recipeName, recipeThumbnail));
+  }
+
+  @PostMapping(path = "/upload-orderImages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<List<String>> uploadOrderImages(
+      HttpServletRequest request,
+      @RequestPart(value = "recipeOrderImages")List<MultipartFile> recipeOrderImages,
+      @RequestParam(value = "recipeName") String recipeName
+  ) throws IOException {
+    return ResponseEntity.ok(pictureService.uploadOrderImages(request, recipeName, recipeOrderImages));
+  }
+
   @PostMapping
   public ResponseEntity<ResultResponse> registerRecipe(
       HttpServletRequest request,
-      @Valid @RequestBody RecipesDTO recipesDTO) {
-    return ResponseEntity.ok(recipeService.registerRecipe(request, recipesDTO));
+      @Valid @RequestBody RecipesDTO recipesDTO,
+      @RequestParam("thumbnailUrl") String thumbnailUrl,
+      @RequestParam("recipeOrderImagesUrl") List<String> recipeOrderImagesUrl) {
+
+    // 레시피 등록 서비스 호출
+    return ResponseEntity.ok(recipeService.registerRecipe(request, recipesDTO, thumbnailUrl, recipeOrderImagesUrl));
   }
 
   @PostMapping("/{recipeId}/scrap")
@@ -85,8 +113,10 @@ public class RecipeController {
   @PutMapping
   public ResponseEntity<ResultResponse> updateRecipe(
       HttpServletRequest request,
-      @Valid @RequestBody RecipesUpdateDTO recipesUpdateDTO) {
-    return ResponseEntity.ok(recipeService.updateRecipe(request, recipesUpdateDTO));
+      @Valid @RequestBody RecipesUpdateDTO recipesUpdateDTO,
+      @RequestParam("thumbnailUrl") String thumbnailUrl,
+      @RequestParam("recipeOrderImagesUrl") List<String> recipeOrderImagesUrl) {
+    return ResponseEntity.ok(recipeService.updateRecipe(request, recipesUpdateDTO, thumbnailUrl, recipeOrderImagesUrl));
   }
 
   @DeleteMapping

--- a/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/controller/RecipeController.java
@@ -10,11 +10,8 @@ import com.recipe.jamanchu.model.type.LevelType;
 import com.recipe.jamanchu.service.RecipeService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import com.recipe.jamanchu.service.PictureService;
-import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,9 +21,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,7 +42,7 @@ public class RecipeController {
   @GetMapping("/search")
   public ResponseEntity<ResultResponse> searchRecipes(
       HttpServletRequest request,
-      @RequestParam(value = "ingredientName",required = false) List<String> ingredients,
+      @RequestParam(value = "ingredientName", required = false) List<String> ingredients,
       @RequestParam(value = "recipeLevel", required = false) LevelType recipeLevel,
       @RequestParam(value = "recipeCookingTime", required = false) CookingTimeType recipeCookingTime,
       @RequestParam(value = "page", defaultValue = "0") int page,

--- a/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeEntity.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/entity/RecipeEntity.java
@@ -86,8 +86,4 @@ public class RecipeEntity extends BaseTimeEntity{
     this.time = time;
     this.thumbnail = thumbnail;
   }
-
-  public void updateThumbnail(String newThumbnail) {
-    this.thumbnail = newThumbnail;
-  }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesDTO.java
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Getter;
-import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 public class RecipesDTO {
@@ -28,7 +27,7 @@ public class RecipesDTO {
   private final CookingTimeType recipeCookingTime;
 
   @JsonProperty("recipeThumbnail")
-  private final MultipartFile recipeThumbnail;
+  private final String recipeThumbnail;
 
   @NotNull(message = "레시피 재료를 입력해주세요.")
   @JsonProperty("recipeIngredients")
@@ -39,7 +38,7 @@ public class RecipesDTO {
   private final List<RecipesManual> recipeOrderContents;
 
   @JsonCreator
-  public RecipesDTO(String recipeName, LevelType recipeLevel, CookingTimeType recipeCookingTime, MultipartFile recipeThumbnail, List<Ingredient> recipeIngredients, List<RecipesManual> recipeOrderContents) {
+  public RecipesDTO(String recipeName, LevelType recipeLevel, CookingTimeType recipeCookingTime, String recipeThumbnail, List<Ingredient> recipeIngredients, List<RecipesManual> recipeOrderContents) {
     this.recipeName = recipeName;
     this.recipeLevel = recipeLevel;
     this.recipeCookingTime = recipeCookingTime;

--- a/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesUpdateDTO.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/model/dto/request/recipe/RecipesUpdateDTO.java
@@ -25,7 +25,7 @@ public class RecipesUpdateDTO extends RecipesDTO{
       String recipeName,
       LevelType level,
       CookingTimeType cookingTime,
-      MultipartFile recipeThumbnail,
+      String recipeThumbnail,
       List<Ingredient> ingredients,
       List<RecipesManual> manuals,
       Long recipeId) {

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/PictureService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/PictureService.java
@@ -1,0 +1,14 @@
+package com.recipe.jamanchu.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface PictureService {
+
+  String uploadThumbnail(HttpServletRequest request, String recipeName, MultipartFile recipeThumbnail) throws IOException;
+
+  List<String> uploadOrderImages(HttpServletRequest request, String recipeName, List<MultipartFile> recipeOrderImages) throws IOException;
+
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/RecipeService.java
@@ -6,14 +6,15 @@ import com.recipe.jamanchu.model.dto.request.recipe.RecipesSearchDTO;
 import com.recipe.jamanchu.model.dto.request.recipe.RecipesUpdateDTO;
 import com.recipe.jamanchu.model.dto.response.ResultResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 
 public interface RecipeService {
 
   // 레시피 작성 API
-  ResultResponse registerRecipe(HttpServletRequest request, RecipesDTO recipesDTO);
+  ResultResponse registerRecipe(HttpServletRequest request, RecipesDTO recipesDTO, String thumbnail, List<String> OrderImages);
 
   // 레시피 수정 API
-  ResultResponse updateRecipe(HttpServletRequest request, RecipesUpdateDTO recipesUpdateDTO);
+  ResultResponse updateRecipe(HttpServletRequest request, RecipesUpdateDTO recipesUpdateDTO, String thumbnail, List<String> OrderImages);
 
   // 모든 레시피 조회 API
   ResultResponse getRecipes(HttpServletRequest request, int page, int size);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/PictureServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/PictureServiceImpl.java
@@ -1,0 +1,50 @@
+package com.recipe.jamanchu.service.impl;
+
+import com.recipe.jamanchu.auth.jwt.JwtUtil;
+import com.recipe.jamanchu.model.type.PictureType;
+import com.recipe.jamanchu.model.type.TokenType;
+import com.recipe.jamanchu.service.PictureService;
+import com.recipe.jamanchu.util.PictureManager;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class PictureServiceImpl implements PictureService {
+
+  private final JwtUtil jwtUtil;
+  private final PictureManager pictureManager;
+
+  @Override
+  public String uploadThumbnail(HttpServletRequest request, String recipeName, MultipartFile recipeThumbnail)
+      throws IOException {
+    Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
+
+    PictureType pictureType = PictureType.THUMBNAIL;
+
+    return pictureManager.upload(userId, recipeName, recipeThumbnail, pictureType);
+  }
+
+  @Override
+  public List<String> uploadOrderImages(HttpServletRequest request, String recipeName,
+      List<MultipartFile> recipeOrderImages) throws IOException {
+    Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
+
+    List<String> recipeOrderImageUrls = new ArrayList<>();
+    if (recipeOrderImages != null) {
+      PictureType pictureType = PictureType.RECIPE_ORDER_IMAGE;
+      for (MultipartFile file : recipeOrderImages) {
+        String uploadedUrl = pictureManager.upload(userId, recipeName, file, pictureType);
+        recipeOrderImageUrls.add(uploadedUrl);
+      }
+    } else {
+      recipeOrderImageUrls.add(null);
+    }
+    return recipeOrderImageUrls;
+  }
+}

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/PictureServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/PictureServiceImpl.java
@@ -25,9 +25,7 @@ public class PictureServiceImpl implements PictureService {
       throws IOException {
     Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
 
-    PictureType pictureType = PictureType.THUMBNAIL;
-
-    return pictureManager.upload(userId, recipeName, recipeThumbnail, pictureType);
+    return pictureManager.upload(userId, recipeName, recipeThumbnail, PictureType.THUMBNAIL);
   }
 
   @Override
@@ -37,9 +35,8 @@ public class PictureServiceImpl implements PictureService {
 
     List<String> recipeOrderImageUrls = new ArrayList<>();
     if (recipeOrderImages != null) {
-      PictureType pictureType = PictureType.RECIPE_ORDER_IMAGE;
       for (MultipartFile file : recipeOrderImages) {
-        String uploadedUrl = pictureManager.upload(userId, recipeName, file, pictureType);
+        String uploadedUrl = pictureManager.upload(userId, recipeName, file, PictureType.RECIPE_ORDER_IMAGE);
         recipeOrderImageUrls.add(uploadedUrl);
       }
     } else {

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/PictureServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/PictureServiceImpl.java
@@ -39,9 +39,8 @@ public class PictureServiceImpl implements PictureService {
         String uploadedUrl = pictureManager.upload(userId, recipeName, file, PictureType.RECIPE_ORDER_IMAGE);
         recipeOrderImageUrls.add(uploadedUrl);
       }
-    } else {
-      recipeOrderImageUrls.add(null);
     }
+
     return recipeOrderImageUrls;
   }
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -63,7 +63,7 @@ public class RecipeServiceImpl implements RecipeService {
 
   @Override
   @Transactional
-  public ResultResponse registerRecipe(HttpServletRequest request, RecipesDTO recipesDTO) {
+  public ResultResponse registerRecipe(HttpServletRequest request, RecipesDTO recipesDTO, String thumbnail, List<String> orderImages) {
     Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
@@ -73,7 +73,7 @@ public class RecipeServiceImpl implements RecipeService {
         .name(recipesDTO.getRecipeName())
         .level(recipesDTO.getRecipeLevel())
         .time(recipesDTO.getRecipeCookingTime())
-        .thumbnail(String.valueOf(recipesDTO.getRecipeThumbnail()))
+        .thumbnail(thumbnail)
         .provider(USER)
         .build();
 
@@ -120,7 +120,7 @@ public class RecipeServiceImpl implements RecipeService {
       ManualEntity manual = ManualEntity.builder()
           .recipe(recipe)
           .manualContent(recipesDTO.getRecipeOrderContents().get(i).getRecipeOrderContent())
-          .manualPicture(recipesDTO.getRecipeOrderContents().get(i).getRecipeOrderImage())
+          .manualPicture(orderImages.get(i))
           .build();
 
       manuals.add(manual);
@@ -134,7 +134,7 @@ public class RecipeServiceImpl implements RecipeService {
   @Override
   @Transactional
   public ResultResponse updateRecipe(HttpServletRequest request,
-      RecipesUpdateDTO recipesUpdateDTO) {
+      RecipesUpdateDTO recipesUpdateDTO, String thumbnail, List<String> orderImages) {
     Long userId = jwtUtil.getUserId(request.getHeader(TokenType.ACCESS.getValue()));
 
     UserEntity user = userAccessHandler.findByUserId(userId);
@@ -150,7 +150,7 @@ public class RecipeServiceImpl implements RecipeService {
 
     recipe.updateRecipe(recipesUpdateDTO.getRecipeName(),
         recipesUpdateDTO.getRecipeLevel(), recipesUpdateDTO.getRecipeCookingTime(),
-        String.valueOf(recipesUpdateDTO.getRecipeThumbnail()));
+      thumbnail);
 
     // 기존 recipeId로 저장된 재료 삭제
     recipeIngredientMappingRepository.deleteAllByRecipeId(recipeId);
@@ -199,7 +199,7 @@ public class RecipeServiceImpl implements RecipeService {
       ManualEntity manual = ManualEntity.builder()
           .recipe(recipe)
           .manualContent(recipesUpdateDTO.getRecipeOrderContents().get(i).getRecipeOrderContent())
-          .manualPicture(recipesUpdateDTO.getRecipeOrderContents().get(i).getRecipeOrderImage())
+          .manualPicture(orderImages.get(i))
           .build();
 
       manuals.add(manual);

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/RecipeServiceImpl.java
@@ -120,7 +120,7 @@ public class RecipeServiceImpl implements RecipeService {
       ManualEntity manual = ManualEntity.builder()
           .recipe(recipe)
           .manualContent(recipesDTO.getRecipeOrderContents().get(i).getRecipeOrderContent())
-          .manualPicture(orderImages.get(i))
+          .manualPicture(i < orderImages.size() ? orderImages.get(i) : null)
           .build();
 
       manuals.add(manual);
@@ -199,7 +199,7 @@ public class RecipeServiceImpl implements RecipeService {
       ManualEntity manual = ManualEntity.builder()
           .recipe(recipe)
           .manualContent(recipesUpdateDTO.getRecipeOrderContents().get(i).getRecipeOrderContent())
-          .manualPicture(orderImages.get(i))
+          .manualPicture(i < orderImages.size() ? orderImages.get(i) : null)
           .build();
 
       manuals.add(manual);

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/RecipeServiceImplTest.java
@@ -101,6 +101,8 @@ class RecipeServiceImplTest {
   private RecipeEntity recipe;
   private RecipesDTO recipesDTO;
   private RecipesUpdateDTO recipesUpdateDTO;
+  private String thumbnailURL;
+  private List<String> orderImagesURL;
 
   @BeforeEach
   void setUp() {
@@ -176,6 +178,16 @@ class RecipeServiceImplTest {
         .ingredients(recipeIngredientEntities)
         .manuals(manualEntities)
         .build();
+
+    thumbnailURL = "thumbnail.jpg";
+
+    String orderImages1 = "orderImages1.jpg";
+    String orderImages2 = "orderImages2.jpg";
+    String orderImages3 = "orderImages3.jpg";
+    orderImagesURL = new ArrayList<>();
+    orderImagesURL.add(orderImages1);
+    orderImagesURL.add(orderImages2);
+    orderImagesURL.add(orderImages3);
   }
 
   @Test
@@ -195,7 +207,7 @@ class RecipeServiceImplTest {
         .thenReturn(Optional.of(existingIngredient));
 
     // when
-    ResultResponse result = recipeService.registerRecipe(request, recipesDTO);
+    ResultResponse result = recipeService.registerRecipe(request, recipesDTO, thumbnailURL, orderImagesURL);
 
     // then
     assertEquals("레시피 등록 성공!", result.getMessage());
@@ -227,7 +239,7 @@ class RecipeServiceImplTest {
             .build()));
 
     // when
-    ResultResponse result = recipeService.registerRecipe(request, recipesDTO);
+    ResultResponse result = recipeService.registerRecipe(request, recipesDTO, thumbnailURL, orderImagesURL);
 
     // then
     assertEquals("레시피 등록 성공!", result.getMessage());
@@ -281,7 +293,7 @@ class RecipeServiceImplTest {
         .thenReturn(List.of(newIngredient));
 
     // When
-    ResultResponse result = recipeService.updateRecipe(request, recipesUpdateDTO);
+    ResultResponse result = recipeService.updateRecipe(request, recipesUpdateDTO, thumbnailURL, orderImagesURL);
 
     // Then
     assertEquals("레시피 수정 성공!", result.getMessage());
@@ -313,7 +325,7 @@ class RecipeServiceImplTest {
 
     // when & then
     assertThrows(UnmatchedUserException.class,
-        () -> recipeService.updateRecipe(request, recipesUpdateDTO));
+        () -> recipeService.updateRecipe(request, recipesUpdateDTO, thumbnailURL, orderImagesURL));
 
     // verify
     verify(recipeRepository, times(1)).findById(1L);


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 썸네일 등록 및 조리순서 이미지 등록하는 api 분리 (/pictures)
  - /pictures/thumbnail , /pictures/orderImages
  - Picture Service 클래스에서 이미지 등록 후 url을 반환하는 로직 처리
  - return은 S3에 저장된 url을 String 형태로 받아옴
- 기존에 레시피 등록 및 수정을 할 때 해당 url을 받아서 처리하도록 프론트에서 구현 예정
- 테스트 코드 수정
- Swagger에서 테스트 완료

## 스크린샷
- 썸네일 이미지 등록 후 url 리턴값
![스크린샷 2024-10-18 오후 11 40 28](https://github.com/user-attachments/assets/302edc28-aa37-4455-9f94-ebe8de90d0d0)
- 조리순서 이미지 여러장 등록 후 url 리턴값
![스크린샷 2024-10-19 오전 12 46 33](https://github.com/user-attachments/assets/9c495ceb-aaf4-4ce5-8efa-5ece76098d1d)

## 주의사항

Closes #124 
