### PR TITLE
[feat] 일반 로그인 카카오 로그인 로직 수정

### DIFF
--- a/jamanchu/src/main/java/com/recipe/jamanchu/component/UserAccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/component/UserAccessHandler.java
@@ -60,7 +60,7 @@ public class UserAccessHandler {
   // 없을 경우 전달 받은 email, nickname, providerId으로 회원 정보 저장 후 반환
   public UserEntity findOrCreateUser(KakaoUserDetails kakaoUserDetails) {
     log.info("findOrCreateUser -> email : {}", kakaoUserDetails.getEmail());
-    return userRepository.findByEmail(kakaoUserDetails.getEmail())
+    return userRepository.findKakaoUser(kakaoUserDetails.getEmail())
         .orElseGet(() -> userRepository.save(UserEntity.builder()
             .email(kakaoUserDetails.getEmail())
             .password(passwordEncoder.encode(String.valueOf(Math.random() * 8)))

--- a/jamanchu/src/main/java/com/recipe/jamanchu/component/UserAccessHandler.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/component/UserAccessHandler.java
@@ -49,9 +49,10 @@ public class UserAccessHandler {
 
   // email 값과 일치하는 회원 정보 반환
   public UserEntity findByEmail(String email) {
-
     log.info("findByEmail -> email : {}", email);
+
     return userRepository.findByEmail(email)
+        .filter(user -> user.getDeletionScheduledAt() == null)
         .orElseThrow(UserNotFoundException::new);
   }
 

--- a/jamanchu/src/main/java/com/recipe/jamanchu/repository/UserRepository.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/repository/UserRepository.java
@@ -26,4 +26,9 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
   @Modifying
   @Query(value = "DELETE FROM user WHERE usr_id = :userId", nativeQuery = true)
   void deleteUserByUserId(@Param("userId") Long userId);
+
+  @Query("SELECT u FROM UserEntity u "
+      + "WHERE u.email = :email "
+      + "AND u.provider IS NOT NULL ")
+  Optional<UserEntity> findKakaoUser(@Param("email") String email);
 }

--- a/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
+++ b/jamanchu/src/main/java/com/recipe/jamanchu/service/impl/UserServiceImpl.java
@@ -99,6 +99,7 @@ public class UserServiceImpl implements UserService {
     return UriComponentsBuilder.fromUriString(REDIRECT_URI)
         .queryParam(TokenType.ACCESS.getValue(), access)
         .queryParam("nickname", user.getNickname())
+        .queryParam("provider", user.getProvider())
         .build()
         .toUriString();
   }

--- a/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
+++ b/jamanchu/src/test/java/com/recipe/jamanchu/service/impl/UserServiceImplTest.java
@@ -253,6 +253,7 @@ class UserServiceImplTest {
     String response = UriComponentsBuilder.fromUriString(REDIRECT_URI)
         .queryParam(TokenType.ACCESS.getValue(), ACCESS)
         .queryParam("nickname", user.getNickname())
+        .queryParam("provider", user.getProvider())
         .build()
         .toUriString();
 


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
일반 로그인 및 카카오 로그인 명확하게 구분을 하기 위해서 조건 식을 추가 하였습니다.
- UserAccessHandler
   - findByEmail() 이메일 값을 통해 User 객체 반환
      -  user 객체가 존재하는 경우
          -  user.getDeletionScheduledAt() 값이 null 이면 user 객체 반환
          -  user.getDeletionScheduledAt() 값이 null 이 아닐 경우 UserNotFoundException 발생
      - user 객체가 존재하지 않은 경우
          - UserNotFoundException 발생  
   - findOrCreateUser
      - 기존 방식에서 추가로 provider 값이 null 이 아닌 객체를 반환
      - 없을 경우 저장 후 해당 객체 반환
- UserServiceImpl
   - kakaoLogin()
      - 카카오 로그인 성공시 반환값에 provider 추가     

문제점
- 카카오로 회원가입을 한 사용자는 회원 탈퇴 후 재로그인을 해도, 접속이 가능합니다.
- 이 부분은 정책으로 풀어서, 탈퇴전 추가로 안내 문구를 제공할 예정입니다.

## 스크린샷

## 주의사항

Closes #129 
