### PR TITLE
[feat] 조건 검색 재료명 부분 검색 되도록 수정

### DIFF
--- a/jamanchu/build.gradle
+++ b/jamanchu/build.gradle
@@ -52,6 +52,15 @@ subprojects {
 		compileOnly 'org.projectlombok:lombok'
 		annotationProcessor 'org.projectlombok:lombok'
 
+		// QueryDSL
+		implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+		annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+		annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+		annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+		// OAuth2
+		implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 		// Mysql
 		runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/config/QuerydslConfig.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.recipe.jamanchu.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+
+}

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/RecipeServiceImpl.java
@@ -292,27 +292,6 @@ public class RecipeServiceImpl implements RecipeService {
 
     return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_RECIPES, recipesSummaries);
   }
-  
-  private Page<RecipeEntity> searchOrRecipes(RecipesSearchDTO recipesSearchDTO,
-      List<Long> scrapedRecipeIds, Pageable pageable) {
-    if (!scrapedRecipeIds.isEmpty()) {
-      return recipeRepository.searchOrRecipesIdNotIn(
-          recipesSearchDTO.getRecipeLevel(),
-          recipesSearchDTO.getRecipeCookingTime(),
-          recipesSearchDTO.getIngredients(),
-          scrapedRecipeIds,
-          pageable
-      );
-    } else {
-      // SCRAPED한 레시피가 없거나 Token이 없으면 Or 조건으로 레시피를 조회
-      return recipeRepository.searchOrRecipes(
-          recipesSearchDTO.getRecipeLevel(),
-          recipesSearchDTO.getRecipeCookingTime(),
-          recipesSearchDTO.getIngredients(),
-          pageable
-      );
-    }
-  }
 
   @Override
   public ResultResponse getRecipeDetail(Long recipeId) {

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/RecipeServiceImpl.java
@@ -276,16 +276,12 @@ public class RecipeServiceImpl implements RecipeService {
     Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
     List<Long> scrapedRecipeIds = getScrapedRecipeIds(request);
 
-    // Page<RecipeEntity> recipes = searchAndRecipes(recipesSearchDTO, scrapedRecipeIds, pageable);
     Page<RecipeEntity> recipes = recipeRepository.searchAndRecipesQueryDSL(
-        recipesSearchDTO.getRecipeLevel(),
-        recipesSearchDTO.getRecipeCookingTime(),
-        recipesSearchDTO.getIngredients(),
-        scrapedRecipeIds,
-        pageable);
+        recipesSearchDTO, scrapedRecipeIds, pageable);
 
     if (recipes.isEmpty()) {
-      recipes = searchOrRecipes(recipesSearchDTO, scrapedRecipeIds, pageable);
+      recipes = recipeRepository.searchOrRecipesQueryDSL(
+          recipesSearchDTO, scrapedRecipeIds, pageable);
     }
 
     if (recipes.isEmpty()) {

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/RecipeServiceImpl.java
@@ -276,7 +276,13 @@ public class RecipeServiceImpl implements RecipeService {
     Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
     List<Long> scrapedRecipeIds = getScrapedRecipeIds(request);
 
-    Page<RecipeEntity> recipes = searchAndRecipes(recipesSearchDTO, scrapedRecipeIds, pageable);
+    // Page<RecipeEntity> recipes = searchAndRecipes(recipesSearchDTO, scrapedRecipeIds, pageable);
+    Page<RecipeEntity> recipes = recipeRepository.searchAndRecipesQueryDSL(
+        recipesSearchDTO.getRecipeLevel(),
+        recipesSearchDTO.getRecipeCookingTime(),
+        recipesSearchDTO.getIngredients(),
+        scrapedRecipeIds,
+        pageable);
 
     if (recipes.isEmpty()) {
       recipes = searchOrRecipes(recipesSearchDTO, scrapedRecipeIds, pageable);
@@ -290,30 +296,7 @@ public class RecipeServiceImpl implements RecipeService {
 
     return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_RECIPES, recipesSummaries);
   }
-
-  private Page<RecipeEntity> searchAndRecipes(RecipesSearchDTO recipesSearchDTO,
-      List<Long> scrapedRecipeIds, Pageable pageable) {
-    if (!scrapedRecipeIds.isEmpty()) {
-      return recipeRepository.searchAndRecipesIdNotIn(
-          recipesSearchDTO.getRecipeLevel(),
-          recipesSearchDTO.getRecipeCookingTime(),
-          recipesSearchDTO.getIngredients(),
-          (long) recipesSearchDTO.getIngredients().size(),
-          scrapedRecipeIds,
-          pageable
-      );
-    } else {
-      // SCRAPED한 레시피가 없거나 Token이 없으면 And 조건으로 레시피를 조회
-      return recipeRepository.searchAndRecipes(
-          recipesSearchDTO.getRecipeLevel(),
-          recipesSearchDTO.getRecipeCookingTime(),
-          recipesSearchDTO.getIngredients(),
-          (long) recipesSearchDTO.getIngredients().size(),
-          pageable
-      );
-    }
-  }
-
+  
   private Page<RecipeEntity> searchOrRecipes(RecipesSearchDTO recipesSearchDTO,
       List<Long> scrapedRecipeIds, Pageable pageable) {
     if (!scrapedRecipeIds.isEmpty()) {

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepository.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepository.java
@@ -2,8 +2,6 @@ package com.recipe.jamanchu.domain.repository;
 
 import com.recipe.jamanchu.domain.entity.RecipeEntity;
 import com.recipe.jamanchu.domain.entity.UserEntity;
-import com.recipe.jamanchu.domain.model.type.CookingTimeType;
-import com.recipe.jamanchu.domain.model.type.LevelType;
 import com.recipe.jamanchu.domain.model.type.ScrapedType;
 
 import java.util.List;

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepository.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepository.java
@@ -15,7 +15,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RecipeRepository extends JpaRepository<RecipeEntity, Long> {
+public interface RecipeRepository extends JpaRepository<RecipeEntity, Long>, RecipeRepositoryCustom {
 
   // AND 조건으로 검색하는 쿼리
   @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepository.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepository.java
@@ -5,6 +5,7 @@ import com.recipe.jamanchu.domain.entity.UserEntity;
 import com.recipe.jamanchu.domain.model.type.CookingTimeType;
 import com.recipe.jamanchu.domain.model.type.LevelType;
 import com.recipe.jamanchu.domain.model.type.ScrapedType;
+
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -16,30 +17,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecipeRepository extends JpaRepository<RecipeEntity, Long>, RecipeRepositoryCustom {
-
-  // AND 조건으로 검색하는 쿼리
-  @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +
-      "WHERE (:ingredients IS NULL OR ri.name IN :ingredients) " +
-      "AND (:cookingTime IS NULL OR r.time = :cookingTime) " +
-      "AND (:level IS NULL OR r.level = :level) " +
-      "GROUP BY r.id " +
-      "HAVING COUNT(ri.name) = :ingredientCount")
-  Page<RecipeEntity> searchAndRecipes(@Param("level") LevelType level,
-      @Param("cookingTime") CookingTimeType cookingTime,
-      @Param("ingredients") List<String> ingredients,
-      @Param("ingredientCount") Long ingredientCount,
-      Pageable pageable);
-
-  // OR 조건으로 검색하는 쿼리
-  @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +
-      "WHERE (:level IS NULL OR r.level = :level) " +
-      "OR (:cookingTime IS NULL OR r.time = :cookingTime) " +
-      "OR (:ingredients IS NULL OR ri.name IN :ingredients) " +
-      "GROUP BY r.id")
-  Page<RecipeEntity> searchOrRecipes(@Param("level") LevelType level,
-      @Param("cookingTime") CookingTimeType cookingTime,
-      @Param("ingredients") List<String> ingredients,
-      Pageable pageable);
 
   // 평점순으로 레시피 가져오는 쿼리
   @Query("SELECT r FROM RecipeEntity r " +
@@ -68,36 +45,6 @@ public interface RecipeRepository extends JpaRepository<RecipeEntity, Long>, Rec
       "GROUP BY r.id " +
       "ORDER BY AVG(rat.rating) DESC")
   Page<RecipeEntity> findByIdNotInOrderByRating(@Param("ids") List<Long> ids, Pageable pageable);
-
-  // 찜 레시피에 해당하는 ids(레시피)는 제외하고 AND 조건으로 검색하는 쿼리
-  @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +
-      "WHERE (:ingredients IS NULL OR ri.name IN :ingredients) " +
-      "AND (:cookingTime IS NULL OR r.time = :cookingTime) " +
-      "AND (:level IS NULL OR r.level = :level) " +
-      "AND (r.id NOT IN :ids) " +
-      "GROUP BY r.id " +
-      "HAVING COUNT(ri.name) = :ingredientCount")
-  Page<RecipeEntity> searchAndRecipesIdNotIn(@Param("level") LevelType level,
-      @Param("cookingTime") CookingTimeType cookingTime,
-      @Param("ingredients") List<String> ingredients,
-      @Param("ingredientCount") Long ingredientCount,
-      @Param("ids") List<Long> ids,
-      Pageable pageable);
-
-  // 찜 레시피에 해당하는 ids(레시피)는 제외하고 OR 조건으로 검색하는 쿼리
-  @Query(value = "SELECT r FROM RecipeEntity r JOIN r.ingredients ri " +
-      "WHERE r.id NOT IN :ids " +  // Apply the exclusion of ids separately
-      "AND (" +  // Start grouping the OR conditions
-      "(:level IS NULL OR r.level = :level) " +
-      "OR (:cookingTime IS NULL OR r.time = :cookingTime) " +
-      "OR (:ingredients IS NULL OR ri.name IN :ingredients)" +
-      ") " +  // End grouping the OR conditions
-      "GROUP BY r.id")
-  Page<RecipeEntity> searchOrRecipesIdNotIn(@Param("level") LevelType level,
-      @Param("cookingTime") CookingTimeType cookingTime,
-      @Param("ingredients") List<String> ingredients,
-      @Param("ids") List<Long> ids,
-      Pageable pageable);
 
   void deleteAllByUser(UserEntity user);
 }

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepository.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepository.java
@@ -11,9 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface RecipeRepository extends JpaRepository<RecipeEntity, Long>, RecipeRepositoryCustom {
 
   // 평점순으로 레시피 가져오는 쿼리

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepositoryCustom.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepositoryCustom.java
@@ -9,6 +9,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface RecipeRepositoryCustom {
   Page<RecipeEntity> searchAndRecipesQueryDSL(LevelType level, CookingTimeType cookingTime,
-      List<String> ingredients, Long ingredientCount,
-      Pageable pageable, List<Long> scrapedRecipeIds);
+      List<String> ingredients, List<Long> scrapedRecipeIds,
+      Pageable pageable);
 }

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepositoryCustom.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepositoryCustom.java
@@ -1,7 +1,7 @@
-package com.recipe.jamanchu.repository;
+package com.recipe.jamanchu.domain.repository;
 
-import com.recipe.jamanchu.entity.RecipeEntity;
-import com.recipe.jamanchu.model.dto.request.recipe.RecipesSearchDTO;
+import com.recipe.jamanchu.domain.entity.RecipeEntity;
+import com.recipe.jamanchu.domain.model.dto.request.recipe.RecipesSearchDTO;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepositoryCustom.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.recipe.jamanchu.repository;
+
+import com.recipe.jamanchu.entity.RecipeEntity;
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RecipeRepositoryCustom {
+  Page<RecipeEntity> searchAndRecipesQueryDSL(LevelType level, CookingTimeType cookingTime,
+      List<String> ingredients, Long ingredientCount,
+      Pageable pageable, List<Long> scrapedRecipeIds);
+}

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepositoryCustom.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/RecipeRepositoryCustom.java
@@ -1,14 +1,15 @@
 package com.recipe.jamanchu.repository;
 
 import com.recipe.jamanchu.entity.RecipeEntity;
-import com.recipe.jamanchu.model.type.CookingTimeType;
-import com.recipe.jamanchu.model.type.LevelType;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesSearchDTO;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface RecipeRepositoryCustom {
-  Page<RecipeEntity> searchAndRecipesQueryDSL(LevelType level, CookingTimeType cookingTime,
-      List<String> ingredients, List<Long> scrapedRecipeIds,
-      Pageable pageable);
+  Page<RecipeEntity> searchAndRecipesQueryDSL(RecipesSearchDTO recipesSearchDTO,
+      List<Long> scrapedRecipeIds, Pageable pageable);
+
+  Page<RecipeEntity> searchOrRecipesQueryDSL(RecipesSearchDTO recipesSearchDTO,
+      List<Long> scrapedRecipeIds, Pageable pageable);
 }

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/impl/RecipeRepositoryCustomImpl.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/impl/RecipeRepositoryCustomImpl.java
@@ -2,16 +2,12 @@ package com.recipe.jamanchu.repository.impl;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.recipe.jamanchu.entity.QRecipeEntity;
 import com.recipe.jamanchu.entity.QRecipeIngredientEntity;
-import com.recipe.jamanchu.entity.QScrapedRecipeEntity;
 import com.recipe.jamanchu.entity.RecipeEntity;
-import com.recipe.jamanchu.model.type.CookingTimeType;
-import com.recipe.jamanchu.model.type.LevelType;
-import com.recipe.jamanchu.model.type.ScrapedType;
+import com.recipe.jamanchu.model.dto.request.recipe.RecipesSearchDTO;
 import com.recipe.jamanchu.repository.RecipeRepositoryCustom;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,8 +22,8 @@ public class RecipeRepositoryCustomImpl implements RecipeRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
   @Override
-  public Page<RecipeEntity> searchAndRecipesQueryDSL(LevelType level, CookingTimeType cookingTime,
-      List<String> ingredients, List<Long> scrapedRecipeIds, Pageable pageable) {
+  public Page<RecipeEntity> searchAndRecipesQueryDSL(RecipesSearchDTO recipesSearchDTO,
+      List<Long> scrapedRecipeIds, Pageable pageable) {
     QRecipeEntity recipe = QRecipeEntity.recipeEntity;
     QRecipeIngredientEntity recipeIngredient = QRecipeIngredientEntity.recipeIngredientEntity;
 
@@ -39,14 +35,14 @@ public class RecipeRepositoryCustomImpl implements RecipeRepositoryCustom {
     BooleanExpression combinedCondition = Expressions.asBoolean(true).isFalse();
 
     // 재료 조건 추가 (모든 재료를 포함하는 조건)
-    if (ingredients != null && !ingredients.isEmpty()) {
-      for (String ingredient : ingredients) {
+    if (recipesSearchDTO.getIngredients() != null && !recipesSearchDTO.getIngredients().isEmpty()) {
+      for (String ingredient : recipesSearchDTO.getIngredients()) {
         combinedCondition = combinedCondition.or(
             recipeIngredient.name.likeIgnoreCase("%" + ingredient + "%"));
       }
 
       // 모든 재료가 포함된 레시피를 찾아야 하므로, 각 재료를 포함하는 레시피 ID를 구합니다.
-      for (String ingredient : ingredients) {
+      for (String ingredient : recipesSearchDTO.getIngredients()) {
         List<Long> ingredientRecipeIds = queryFactory.select(recipe.id)
             .from(recipe)
             .join(recipe.ingredients, recipeIngredient)
@@ -58,13 +54,65 @@ public class RecipeRepositoryCustomImpl implements RecipeRepositoryCustom {
     }
 
     // 난이도 조건 추가
-    if (level != null) {
-      combinedCondition = combinedCondition.and(recipe.level.eq(level));
+    if (recipesSearchDTO.getRecipeLevel() != null) {
+      combinedCondition = combinedCondition.and(recipe.level.eq(recipesSearchDTO.getRecipeLevel()));
     }
 
     // 요리 시간 조건 추가
-    if (cookingTime != null) {
-      combinedCondition = combinedCondition.and(recipe.time.eq(cookingTime));
+    if (recipesSearchDTO.getRecipeCookingTime() != null) {
+      combinedCondition = combinedCondition.and(recipe.time.eq(recipesSearchDTO.getRecipeCookingTime()));
+    }
+
+    // 스크랩된 레시피 제외 조건 추가
+    if (!scrapedRecipeIds.isEmpty()) {
+      combinedCondition = combinedCondition.and(recipe.id.notIn(scrapedRecipeIds));
+    }
+
+    // 모든 조건을 쿼리에 추가
+    query.where(combinedCondition);
+
+    // 페이징 처리
+    long total = query.fetchCount();
+    List<RecipeEntity> results = query.offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    return new PageImpl<>(results, pageable, total);
+  }
+
+  @Override
+  public Page<RecipeEntity> searchOrRecipesQueryDSL(RecipesSearchDTO recipesSearchDTO,
+      List<Long> scrapedRecipeIds, Pageable pageable) {
+    QRecipeEntity recipe = QRecipeEntity.recipeEntity;
+    QRecipeIngredientEntity recipeIngredient = QRecipeIngredientEntity.recipeIngredientEntity;
+
+    // 기본 쿼리
+    JPQLQuery<RecipeEntity> query = queryFactory.selectFrom(recipe)
+        .join(recipe.ingredients, recipeIngredient);
+
+    // 조건 중 하나라도 있어야 하므로, 기본 조건을 생성합니다.
+    BooleanExpression combinedCondition = Expressions.asBoolean(true).isFalse();
+
+    // 재료 조건 추가 (모든 재료를 포함하는 조건)
+    if (recipesSearchDTO.getIngredients() != null && !recipesSearchDTO.getIngredients().isEmpty()) {
+      BooleanExpression ingredientCondition = null;
+
+      for (String ingredient : recipesSearchDTO.getIngredients()) {
+        BooleanExpression singleIngredientCondition = recipeIngredient.name.likeIgnoreCase("%" + ingredient + "%");
+        ingredientCondition = (ingredientCondition == null) ? singleIngredientCondition : ingredientCondition.or(singleIngredientCondition);
+      }
+
+      combinedCondition = combinedCondition.or(ingredientCondition);
+    }
+
+    // 난이도 조건 추가
+    if (recipesSearchDTO.getRecipeLevel() != null) {
+      combinedCondition = combinedCondition.or(recipe.level.eq(recipesSearchDTO.getRecipeLevel()));
+    }
+
+    // 요리 시간 조건 추가
+    if (recipesSearchDTO.getRecipeCookingTime() != null) {
+      combinedCondition = combinedCondition.or(recipe.time.eq(recipesSearchDTO.getRecipeCookingTime()));
     }
 
     // 스크랩된 레시피 제외 조건 추가

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/impl/RecipeRepositoryCustomImpl.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/impl/RecipeRepositoryCustomImpl.java
@@ -1,0 +1,86 @@
+package com.recipe.jamanchu.repository.impl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.recipe.jamanchu.entity.QRecipeEntity;
+import com.recipe.jamanchu.entity.QRecipeIngredientEntity;
+import com.recipe.jamanchu.entity.QScrapedRecipeEntity;
+import com.recipe.jamanchu.entity.RecipeEntity;
+import com.recipe.jamanchu.model.type.CookingTimeType;
+import com.recipe.jamanchu.model.type.LevelType;
+import com.recipe.jamanchu.model.type.ScrapedType;
+import com.recipe.jamanchu.repository.RecipeRepositoryCustom;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RecipeRepositoryCustomImpl implements RecipeRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+  @Override
+  public Page<RecipeEntity> searchAndRecipesQueryDSL(LevelType level, CookingTimeType cookingTime,
+      List<String> ingredients, Long ingredientCount, Pageable pageable, List<Long> scrapedRecipeIds) {
+    QRecipeEntity recipe = QRecipeEntity.recipeEntity;
+    QRecipeIngredientEntity recipeIngredient = QRecipeIngredientEntity.recipeIngredientEntity;
+
+    // 기본 쿼리
+    JPQLQuery<RecipeEntity> query = queryFactory.selectFrom(recipe)
+        .join(recipe.ingredients, recipeIngredient);
+
+    // 조건 중 하나라도 있어야 하므로, 기본 조건을 생성합니다.
+    BooleanExpression combinedCondition = Expressions.asBoolean(true).isFalse();
+
+    // 재료 조건 추가 (모든 재료를 포함하는 조건)
+    if (ingredients != null && !ingredients.isEmpty()) {
+      for (String ingredient : ingredients) {
+        combinedCondition = combinedCondition.or(
+            recipeIngredient.name.likeIgnoreCase("%" + ingredient + "%"));
+      }
+
+      // 모든 재료가 포함된 레시피를 찾아야 하므로, 각 재료를 포함하는 레시피 ID를 구합니다.
+      for (String ingredient : ingredients) {
+        List<Long> ingredientRecipeIds = queryFactory.select(recipe.id)
+            .from(recipe)
+            .join(recipe.ingredients, recipeIngredient)
+            .where(recipeIngredient.name.likeIgnoreCase("%" + ingredient + "%"))
+            .fetch();
+
+        combinedCondition = combinedCondition.and(recipe.id.in(ingredientRecipeIds));
+      }
+    }
+
+    // 난이도 조건 추가
+    if (level != null) {
+      combinedCondition = combinedCondition.and(recipe.level.eq(level));
+    }
+
+    // 요리 시간 조건 추가
+    if (cookingTime != null) {
+      combinedCondition = combinedCondition.and(recipe.time.eq(cookingTime));
+    }
+
+    // 스크랩된 레시피 제외 조건 추가  --> 테스트 필요
+    if (!scrapedRecipeIds.isEmpty()) {
+      combinedCondition = combinedCondition.and(recipe.id.notIn(scrapedRecipeIds));
+    }
+
+    // 모든 조건을 쿼리에 추가
+    query.where(combinedCondition);
+
+    // 페이징 처리
+    long total = query.fetchCount();
+    List<RecipeEntity> results = query.offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    return new PageImpl<>(results, pageable, total);
+  }
+}

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/impl/RecipeRepositoryCustomImpl.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/impl/RecipeRepositoryCustomImpl.java
@@ -27,7 +27,7 @@ public class RecipeRepositoryCustomImpl implements RecipeRepositoryCustom {
   private final JPAQueryFactory queryFactory;
   @Override
   public Page<RecipeEntity> searchAndRecipesQueryDSL(LevelType level, CookingTimeType cookingTime,
-      List<String> ingredients, Long ingredientCount, Pageable pageable, List<Long> scrapedRecipeIds) {
+      List<String> ingredients, List<Long> scrapedRecipeIds, Pageable pageable) {
     QRecipeEntity recipe = QRecipeEntity.recipeEntity;
     QRecipeIngredientEntity recipeIngredient = QRecipeIngredientEntity.recipeIngredientEntity;
 
@@ -67,7 +67,7 @@ public class RecipeRepositoryCustomImpl implements RecipeRepositoryCustom {
       combinedCondition = combinedCondition.and(recipe.time.eq(cookingTime));
     }
 
-    // 스크랩된 레시피 제외 조건 추가  --> 테스트 필요
+    // 스크랩된 레시피 제외 조건 추가
     if (!scrapedRecipeIds.isEmpty()) {
       combinedCondition = combinedCondition.and(recipe.id.notIn(scrapedRecipeIds));
     }

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/impl/RecipeRepositoryCustomImpl.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/impl/RecipeRepositoryCustomImpl.java
@@ -29,6 +29,7 @@ public class RecipeRepositoryCustomImpl implements RecipeRepositoryCustom {
 
     // 기본 쿼리
     JPQLQuery<RecipeEntity> query = queryFactory.selectFrom(recipe)
+        .distinct()
         .join(recipe.ingredients, recipeIngredient);
 
     // 조건 중 하나라도 있어야 하므로, 기본 조건을 생성합니다.
@@ -88,6 +89,7 @@ public class RecipeRepositoryCustomImpl implements RecipeRepositoryCustom {
 
     // 기본 쿼리
     JPQLQuery<RecipeEntity> query = queryFactory.selectFrom(recipe)
+        .distinct()
         .join(recipe.ingredients, recipeIngredient);
 
     // 조건 중 하나라도 있어야 하므로, 기본 조건을 생성합니다.

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/impl/RecipeRepositoryCustomImpl.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/impl/RecipeRepositoryCustomImpl.java
@@ -1,14 +1,14 @@
-package com.recipe.jamanchu.repository.impl;
+package com.recipe.jamanchu.domain.repository.impl;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.recipe.jamanchu.entity.QRecipeEntity;
-import com.recipe.jamanchu.entity.QRecipeIngredientEntity;
-import com.recipe.jamanchu.entity.RecipeEntity;
-import com.recipe.jamanchu.model.dto.request.recipe.RecipesSearchDTO;
-import com.recipe.jamanchu.repository.RecipeRepositoryCustom;
+import com.recipe.jamanchu.domain.entity.RecipeEntity;
+import com.recipe.jamanchu.domain.model.dto.request.recipe.RecipesSearchDTO;
+import com.recipe.jamanchu.domain.repository.RecipeRepositoryCustom;
+import com.recipe.jamanchu.domain.entity.QRecipeEntity;
+import com.recipe.jamanchu.domain.entity.QRecipeIngredientEntity;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 기존 구현 : 재료 키워드 입력 시 일치하는 재료명이 있는 레시피만 반환하도록 구현
- 수정 구현 : 재료 키워드 입력 시 해당 재료명이 포함된 모든 재료명이 있는 레시피를 반환하도록 수정
- 재료의 갯수, 난이도, 조리 시간이라는 유동적인 조건들을 처리하기 위해서 동적 쿼리로 구현하기 위해 QueryDSL 추가
  - **build.gradle** 수정
  - **QuerydslConfig** 추가
- **RecipeRepositoryCustomImpl**
  - searchAnd 쿼리와 searchOr 쿼리 QueryDSL로 구현
- **RecipeRepository**
  - 사용하지 않는 기존의 쿼리 삭제
- 테스트 코드 수정 및 Swagger에서 테스트 완료

## 스크린샷

## 주의사항

Closes #133 