### PR TITLE
[feat] 레시피 조회 시에 전체 레시피 갯수도 반환하도록 추가

### DIFF
--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/RecipeServiceImpl.java
@@ -41,7 +41,9 @@ import com.recipe.jamanchu.domain.repository.SeasoningRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -273,10 +275,11 @@ public class RecipeServiceImpl implements RecipeService {
       throw new RecipeNotFoundException();
     }
 
-    List<RecipesSummary> recipesSummaries = convertToRecipesSummary(recipes);
+    // 결과 응답에 레시피 리스트와 총 레시피 개수 포함
+    Map<String, Object> responseData = convertToRecipesSummary(recipes);
 
     // 결과 반환
-    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_ALL_RECIPES, recipesSummaries);
+    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_ALL_RECIPES, responseData);
   }
 
   @Override
@@ -297,9 +300,10 @@ public class RecipeServiceImpl implements RecipeService {
       throw new RecipeNotFoundException();
     }
 
-    List<RecipesSummary> recipesSummaries = convertToRecipesSummary(recipes);
+    // 결과 응답에 레시피 리스트와 총 레시피 개수 포함
+    Map<String, Object> responseData = convertToRecipesSummary(recipes);
 
-    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_RECIPES, recipesSummaries);
+    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_RECIPES, responseData);
   }
 
   @Override
@@ -355,9 +359,10 @@ public class RecipeServiceImpl implements RecipeService {
       throw new RecipeNotFoundException();
     }
 
-    List<RecipesSummary> recipesSummaries = convertToRecipesSummary(recipes);
+    // 결과 응답에 레시피 리스트와 총 레시피 개수 포함
+    Map<String, Object> responseData = convertToRecipesSummary(recipes);
 
-    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_ALL_RECIPES_BY_RATING, recipesSummaries);
+    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_ALL_RECIPES_BY_RATING, responseData);
   }
 
   @Override
@@ -469,9 +474,9 @@ public class RecipeServiceImpl implements RecipeService {
     return scrapedRecipeIds;
   }
 
-  // RecipeEntity 리스트를 RecipesSummary로 변환하는 메서드
-  private List<RecipesSummary> convertToRecipesSummary(Page<RecipeEntity> recipes) {
-    return recipes.stream().map(
+  // RecipeEntity 리스트를 RecipesSummary와 총 레시피 갯수로 변환하는 메서드
+  private Map<String, Object> convertToRecipesSummary(Page<RecipeEntity> recipes) {
+    List<RecipesSummary> recipesSummaries = recipes.stream().map(
         recipeEntity -> new RecipesSummary(
             recipeEntity.getId(),
             recipeEntity.getName(),
@@ -484,5 +489,15 @@ public class RecipeServiceImpl implements RecipeService {
                 .orElse(0.0)
         )
     ).toList();
+
+    // 총 레시피 개수를 가져옴
+    long totalRecipes = recipes.getTotalElements();
+
+    // 결과 응답에 레시피 리스트와 총 레시피 개수 포함
+    Map<String, Object> responseData = new HashMap<>();
+    responseData.put("recipes", recipesSummaries);
+    responseData.put("totalRecipes", totalRecipes);
+
+    return responseData;
   }
 }

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/RecipeServiceImpl.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/RecipeServiceImpl.java
@@ -275,11 +275,7 @@ public class RecipeServiceImpl implements RecipeService {
       throw new RecipeNotFoundException();
     }
 
-    // 결과 응답에 레시피 리스트와 총 레시피 개수 포함
-    Map<String, Object> responseData = convertToRecipesSummary(recipes);
-
-    // 결과 반환
-    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_ALL_RECIPES, responseData);
+    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_ALL_RECIPES, convertToRecipesSummary(recipes));
   }
 
   @Override
@@ -300,10 +296,7 @@ public class RecipeServiceImpl implements RecipeService {
       throw new RecipeNotFoundException();
     }
 
-    // 결과 응답에 레시피 리스트와 총 레시피 개수 포함
-    Map<String, Object> responseData = convertToRecipesSummary(recipes);
-
-    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_RECIPES, responseData);
+    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_RECIPES, convertToRecipesSummary(recipes));
   }
 
   @Override
@@ -359,10 +352,7 @@ public class RecipeServiceImpl implements RecipeService {
       throw new RecipeNotFoundException();
     }
 
-    // 결과 응답에 레시피 리스트와 총 레시피 개수 포함
-    Map<String, Object> responseData = convertToRecipesSummary(recipes);
-
-    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_ALL_RECIPES_BY_RATING, responseData);
+    return ResultResponse.of(ResultCode.SUCCESS_RETRIEVE_ALL_RECIPES_BY_RATING, convertToRecipesSummary(recipes));
   }
 
   @Override


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 레시피를 조회하는 API에서 Response에 전체 레시피 갯수도 같이 반환하도록 구현
  - 기존에 convertToRecipesSummary 함수에 내용 추가 구현
- Swagger 테스트 완료
- API 문서 수정 완료
## 스크린샷

## 주의사항

Closes #154 
