### PR TITLE
[fix] 알림 기능 수정 및 Controller URI 명시적으로 수정

### DIFF
--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/notify/IgnoreRecipeCommentAlarmMap.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/notify/IgnoreRecipeCommentAlarmMap.java
@@ -68,4 +68,17 @@ public class IgnoreRecipeCommentAlarmMap implements Map<Long, Set<Long>> {
   public Set<Entry<Long, Set<Long>>> entrySet() {
     return this.ignoreAlarmRecipeIds.entrySet();
   }
+
+  public boolean containsIgnore(Long userId, Long recipeId) {
+    return this.ignoreAlarmRecipeIds.containsKey(userId) && this.ignoreAlarmRecipeIds.get(userId)
+        .contains(recipeId);
+  }
+
+  public void addIgnore(Long userId, Long recipeId) {
+    this.ignoreAlarmRecipeIds.get(userId).add(recipeId);
+  }
+
+  public void removeIgnore(Long userId, Long recipeId) {
+    this.ignoreAlarmRecipeIds.get(userId).remove(recipeId);
+  }
 }

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/notify/NotifyController.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/notify/NotifyController.java
@@ -28,7 +28,7 @@ public class NotifyController {
   }
 
   // 특정 레시피에 대한 알림 toggle
-  @GetMapping("/notify/ignore/{recipeId}")
+  @GetMapping("/notify/toggle/{recipeId}")
   public ResponseEntity<ResultResponse> toggleRecipeCommentAlarm(HttpServletRequest request,
       @PathVariable("recipeId") Long recipeId) {
     return ResponseEntity.ok(notifyService.toggleRecipeComment(request, recipeId));

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/NotifyServiceImpl.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/NotifyServiceImpl.java
@@ -131,7 +131,7 @@ public class NotifyServiceImpl implements NotifyService {
 
     Optional<List<RecipeEntity>> allByUser = recipeRepository.findAllByUser(user);
 
-    List<Long> list = List.of();
+    List<Long> list = new ArrayList<>();
     if (allByUser.isPresent()) {
       list = new ArrayList<>(allByUser.get().stream()
           .map(RecipeEntity::getId)

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/NotifyServiceImpl.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/NotifyServiceImpl.java
@@ -16,6 +16,7 @@ import com.recipe.jamanchu.domain.repository.RecipeRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -104,18 +105,15 @@ public class NotifyServiceImpl implements NotifyService {
       Long recipeId) {
 
     Long userId = jwtUtil.getUserId(request.getHeader(ACCESS.getValue()));
-
     userAccessHandler.existsById(userId);
-
     if (ignoreAlarmRecipeIds.containsKey(userId)) {
-      Set<Long> ignoreRecipeIds = ignoreAlarmRecipeIds.get(userId);
-      if (ignoreRecipeIds.contains(recipeId)) {
-        ignoreRecipeIds.remove(recipeId);
+      if (ignoreAlarmRecipeIds.containsIgnore(userId,recipeId)) {
+        ignoreAlarmRecipeIds.removeIgnore(userId,recipeId);
       } else {
-        ignoreRecipeIds.add(recipeId);
+        ignoreAlarmRecipeIds.addIgnore(userId,recipeId);
       }
     } else {
-      ignoreAlarmRecipeIds.put(userId, Set.of(recipeId));
+      ignoreAlarmRecipeIds.put(userId, new HashSet<>(Set.of(recipeId)));
     }
 
     return getNotifyList(request);

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/NotifyServiceImpl.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/NotifyServiceImpl.java
@@ -43,7 +43,7 @@ public class NotifyServiceImpl implements NotifyService {
 
     userAccessHandler.existsById(userId);
 
-    SseEmitter sseEmitter = new SseEmitter();
+    SseEmitter sseEmitter = new SseEmitter(600_000_000L); //  1000분간 알림 설정 (임시)
     subscribers.put(userId, sseEmitter);
 
     // SSE 연결 해제 시

--- a/jamanchu/module-api/src/test/java/com/recipe/jamanchu/api/service/impl/NotifyServiceImplTest.java
+++ b/jamanchu/module-api/src/test/java/com/recipe/jamanchu/api/service/impl/NotifyServiceImplTest.java
@@ -21,8 +21,6 @@ import com.recipe.jamanchu.domain.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.domain.model.dto.response.notify.Notify;
 import com.recipe.jamanchu.domain.repository.RecipeRepository;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
* 기존코드에서 Set을 삽입할 때, Set.of(recipeId)로 삽입했던 문제
* 해당 방법으로 진행 시, 객체가 Immutable Object로 생성 되어서, UnsupportedOperationException 예외 발생
* new HashSet<>()을 통해 삽입하여 가변 객체로 변경

* 기존의 new SseEmitter로 사용할 시, 기본 Time Out이 30초였던 것을 파악하지 못함. 테스트 도중 연결 해제되는 문제 발생
* 임시로 Time out을 늘려서 해결 -> 보다 근본적인 해결책이 필요해보임

* IgnoreRecipeCommentAlarmMap 내부에 Set 자료를 검증, 삽입, 삭제할 수 있는 메서드 추가

* Controller URI 수정을 통해서 보다 명시적으로 변경 

## 스크린샷

## 주의사항

Closes #160 
