### PR TITLE
[feat] 비밀번호 찾기 api 구현

### DIFF
--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/config/SecurityConfig.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/config/SecurityConfig.java
@@ -55,6 +55,8 @@ public class SecurityConfig {
                 "/api/v1/users/login",
                 "/api/v1/auth/email-check",
                 "/api/v1/auth/nickname-check",
+                "/api/v1/auth/find-password",
+                "/api/v1/auth/update-password",
                 "/favicon.ico",
                 "/api/v1/users/login/auth/kakao",
                 "/api/v1/auth/token/refresh").permitAll()

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/controller/AuthController.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/controller/AuthController.java
@@ -71,7 +71,7 @@ public class AuthController {
 
   @PostMapping("/update-password")
   public ResponseEntity<ResultResponse> updatePassword(
-      @RequestBody PasswordUpdateDTO passwordUpdateDTO
+      @Valid @RequestBody PasswordUpdateDTO passwordUpdateDTO
   ) {
     return ResponseEntity.ok(authService.updatePassword(passwordUpdateDTO));
   }

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/controller/AuthController.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/controller/AuthController.java
@@ -60,7 +60,7 @@ public class AuthController {
     return ResponseEntity.ok(authService.checkPassword(passwordCheckDTO, request));
   }
 
-  @PostMapping("/find-password")
+  @GetMapping("/find-password")
   public ResponseEntity<ResultResponse> findPassword(
       @RequestParam(name = "email") String email,
       @RequestParam(name = "nickname") String nickname

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/controller/AuthController.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/controller/AuthController.java
@@ -59,4 +59,20 @@ public class AuthController {
 
     return ResponseEntity.ok(authService.checkPassword(passwordCheckDTO, request));
   }
+
+  @PostMapping("/find-password")
+  public ResponseEntity<ResultResponse> findPassword(
+      @RequestParam(name = "email") String email,
+      @RequestParam(name = "nickname") String nickname
+  ) {
+    return ResponseEntity.ok(authService.findPassword(email, nickname));
+  }
+
+  @PostMapping("/update-password")
+  public ResponseEntity<ResultResponse> updatePassword(
+      @RequestParam(name = "userId") Long userId,
+      @RequestParam(name = "password") String password
+  ) {
+    return ResponseEntity.ok(authService.updatePassword(userId, password));
+  }
 }

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/controller/AuthController.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.recipe.jamanchu.api.controller;
 import com.recipe.jamanchu.core.exceptions.exception.MissingEmailException;
 import com.recipe.jamanchu.core.exceptions.exception.MissingNicknameException;
 import com.recipe.jamanchu.domain.model.dto.request.auth.PasswordCheckDTO;
+import com.recipe.jamanchu.domain.model.dto.request.auth.PasswordUpdateDTO;
 import com.recipe.jamanchu.domain.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.api.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -70,9 +71,8 @@ public class AuthController {
 
   @PostMapping("/update-password")
   public ResponseEntity<ResultResponse> updatePassword(
-      @RequestParam(name = "userId") Long userId,
-      @RequestParam(name = "password") String password
+      @RequestBody PasswordUpdateDTO passwordUpdateDTO
   ) {
-    return ResponseEntity.ok(authService.updatePassword(userId, password));
+    return ResponseEntity.ok(authService.updatePassword(passwordUpdateDTO));
   }
 }

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/AuthService.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/AuthService.java
@@ -14,4 +14,8 @@ public interface AuthService {
   ResultResponse refreshToken(HttpServletRequest request, HttpServletResponse response);
 
   ResultResponse checkPassword(PasswordCheckDTO passwordCheckDTO, HttpServletRequest request);
+
+  ResultResponse findPassword(String email, String nickname);
+
+  ResultResponse updatePassword(Long userId, String password);
 }

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/AuthService.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.recipe.jamanchu.api.service;
 
 import com.recipe.jamanchu.domain.model.dto.request.auth.PasswordCheckDTO;
+import com.recipe.jamanchu.domain.model.dto.request.auth.PasswordUpdateDTO;
 import com.recipe.jamanchu.domain.model.dto.response.ResultResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,5 +18,5 @@ public interface AuthService {
 
   ResultResponse findPassword(String email, String nickname);
 
-  ResultResponse updatePassword(Long userId, String password);
+  ResultResponse updatePassword(PasswordUpdateDTO passwordUpdateDTO);
 }

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/AuthServiceImpl.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/AuthServiceImpl.java
@@ -6,6 +6,7 @@ import com.recipe.jamanchu.domain.entity.UserEntity;
 import com.recipe.jamanchu.core.exceptions.exception.CookieNotFoundException;
 import com.recipe.jamanchu.core.exceptions.exception.RefreshTokenExpiredException;
 import com.recipe.jamanchu.domain.model.dto.request.auth.PasswordCheckDTO;
+import com.recipe.jamanchu.domain.model.dto.request.auth.PasswordUpdateDTO;
 import com.recipe.jamanchu.domain.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.domain.model.type.ResultCode;
 import com.recipe.jamanchu.domain.model.type.TokenType;
@@ -89,7 +90,7 @@ public class AuthServiceImpl implements AuthService {
   }
 
   @Override
-  public ResultResponse updatePassword(Long userId, String password) {
-    return userAccessHandler.updatePassword(userId, password);
+  public ResultResponse updatePassword(PasswordUpdateDTO passwordUpdateDTO) {
+    return userAccessHandler.updatePassword(passwordUpdateDTO);
   }
 }

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/AuthServiceImpl.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/impl/AuthServiceImpl.java
@@ -82,4 +82,14 @@ public class AuthServiceImpl implements AuthService {
 
     return userAccessHandler.validateBeforePW(user.getPassword(), passwordCheckDTO.getPassword());
   }
+
+  @Override
+  public ResultResponse findPassword(String email, String nickname) {
+    return userAccessHandler.findPassword(email, nickname);
+  }
+
+  @Override
+  public ResultResponse updatePassword(Long userId, String password) {
+    return userAccessHandler.updatePassword(userId, password);
+  }
 }

--- a/jamanchu/module-api/src/test/java/com/recipe/jamanchu/api/component/UserAccessHandlerTest.java
+++ b/jamanchu/module-api/src/test/java/com/recipe/jamanchu/api/component/UserAccessHandlerTest.java
@@ -418,4 +418,90 @@ class UserAccessHandlerTest {
     verify(userRepository, times(1)).deleteUserByUserId(user2.getUserId());
   }
 
+  @Test
+  @DisplayName("이메일과 닉네임이 일치할 때 비밀번호 찾기 성공")
+  void testFindPasswordSuccess() {
+    // given
+    String email = "test@example.com";
+    String nickname = "testNickname";
+    UserEntity user = UserEntity.builder()
+        .userId(1L)
+        .email(email)
+        .nickname(nickname)
+        .build();
+
+    // when
+    when(userRepository.existsByEmailAndNickname(email, nickname)).thenReturn(true);
+    when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+    // then
+    ResultResponse result = userAccessHandler.findPassword(email, nickname);
+    assertEquals("비밀번호를 수정할 수 있습니다.", result.getMessage());
+    Map<String, Object> responseData = (Map<String, Object>) result.getData();
+    assertEquals(1L, responseData.get("userId"));
+    assertEquals(true, responseData.get("boolean"));
+  }
+
+  @Test
+  @DisplayName("이메일과 닉네임이 일치하지 않을 때")
+  void testFindPasswordEmailNicknameMismatch() {
+    // given
+    String email = "test@example.com";
+    String nickname = "wrongNickname";
+
+    // when
+    Mockito.when(userRepository.existsByEmailAndNickname(email, nickname)).thenReturn(false);
+
+    // then
+    ResultResponse result = userAccessHandler.findPassword(email, nickname);
+    assertEquals("회원 정보를 다시 확인해주세요.", result.getMessage());
+    assertEquals(false, result.getData());
+  }
+
+  @Test
+  @DisplayName("이메일과 닉네임이 일치하지만 사용자가 존재하지 않는 경우")
+  void testFindPasswordUserNotFound() {
+    // given
+    String email = "test@example.com";
+    String nickname = "testNickname";
+
+    // when
+    Mockito.when(userRepository.existsByEmailAndNickname(email, nickname)).thenReturn(true);
+    Mockito.when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+    // then
+    assertThrows(UserNotFoundException.class, () -> {
+      userAccessHandler.findPassword(email, nickname);
+    });
+  }
+
+  @Test
+  @DisplayName("비밀번호를 정상적으로 업데이트 한 경우")
+  public void testUpdatePassword() {
+    // Given
+    Long userId = 1L;
+    String newPassword = "newPassword123";
+    String encodedPassword = "encodedPassword123";
+
+    UserEntity user = UserEntity.builder()
+        .userId(userId)
+        .build();
+
+    // When
+    when(userRepository.findByUserId(userId)).thenReturn(Optional.of(user));
+    when(passwordEncoder.encode(newPassword)).thenReturn(encodedPassword);
+
+    // 실제로 비밀번호가 업데이트되는지 확인
+    ResultResponse result = userAccessHandler.updatePassword(userId, newPassword);
+
+    // Then
+    assertEquals("비밀번호를 수정했습니다.", result.getMessage());
+    assertEquals(encodedPassword, user.getPassword());
+
+    // verify
+    verify(userRepository).findByUserId(userId);
+    verify(passwordEncoder).encode(newPassword);
+    verify(userRepository).save(user);
+  }
+
 }

--- a/jamanchu/module-api/src/test/java/com/recipe/jamanchu/api/component/UserAccessHandlerTest.java
+++ b/jamanchu/module-api/src/test/java/com/recipe/jamanchu/api/component/UserAccessHandlerTest.java
@@ -17,6 +17,7 @@ import com.recipe.jamanchu.core.exceptions.exception.PasswordMismatchException;
 import com.recipe.jamanchu.core.exceptions.exception.SocialAccountException;
 import com.recipe.jamanchu.core.exceptions.exception.UserNotFoundException;
 import com.recipe.jamanchu.core.exceptions.exception.WithdrewUserException;
+import com.recipe.jamanchu.domain.model.dto.request.auth.PasswordUpdateDTO;
 import com.recipe.jamanchu.domain.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.domain.model.type.ResultCode;
 import com.recipe.jamanchu.domain.repository.CommentRepository;
@@ -482,6 +483,10 @@ class UserAccessHandlerTest {
     Long userId = 1L;
     String newPassword = "newPassword123";
     String encodedPassword = "encodedPassword123";
+    PasswordUpdateDTO passwordUpdateDTO = new PasswordUpdateDTO(
+        userId,
+        newPassword
+    );
 
     UserEntity user = UserEntity.builder()
         .userId(userId)
@@ -492,7 +497,7 @@ class UserAccessHandlerTest {
     when(passwordEncoder.encode(newPassword)).thenReturn(encodedPassword);
 
     // 실제로 비밀번호가 업데이트되는지 확인
-    ResultResponse result = userAccessHandler.updatePassword(userId, newPassword);
+    ResultResponse result = userAccessHandler.updatePassword(passwordUpdateDTO);
 
     // Then
     assertEquals("비밀번호를 수정했습니다.", result.getMessage());

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/component/UserAccessHandler.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/component/UserAccessHandler.java
@@ -17,7 +17,9 @@ import com.recipe.jamanchu.domain.repository.RecipeRepository;
 import com.recipe.jamanchu.domain.repository.ScrapedRecipeRepository;
 import com.recipe.jamanchu.domain.repository.UserRepository;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -183,6 +185,29 @@ public class UserAccessHandler {
     ingredientRatingRepository.deleteAllByUser(user);
     // 작성한 레시피
     recipeRepository.deleteAllByUser(user);
+  }
+
+  public ResultResponse findPassword(String email, String nickname) {
+    if (!userRepository.existsByEmailAndNickname(email, nickname)) {
+      return ResultResponse.of(ResultCode.EMAIL_NICKNAME_MISMATCH, false);
+    }
+
+    UserEntity user = userRepository.findByEmail(email)
+        .orElseThrow(UserNotFoundException::new);
+
+    Map<String, Object> responseData = new HashMap<>();
+    responseData.put("userId", user.getUserId());
+    responseData.put("boolean", true);
+    return ResultResponse.of(ResultCode.EMAIL_NICKNAME_MATCH, responseData);
+  }
+
+  public ResultResponse updatePassword(Long userId, String password) {
+    UserEntity user = userRepository.findByUserId(userId)
+        .orElseThrow(UserNotFoundException::new);
+
+    user.updatePassword(passwordEncoder.encode(password));
+    saveUser(user);
+    return ResultResponse.of(ResultCode.SUCCESS_UPDATE_PASSWORD);
   }
 }
 

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/component/UserAccessHandler.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/component/UserAccessHandler.java
@@ -7,6 +7,7 @@ import com.recipe.jamanchu.core.exceptions.exception.UserNotFoundException;
 import com.recipe.jamanchu.core.exceptions.exception.WithdrewUserException;
 import com.recipe.jamanchu.domain.entity.UserEntity;
 import com.recipe.jamanchu.domain.model.auth.KakaoUserDetails;
+import com.recipe.jamanchu.domain.model.dto.request.auth.PasswordUpdateDTO;
 import com.recipe.jamanchu.domain.model.dto.response.ResultResponse;
 import com.recipe.jamanchu.domain.model.type.ResultCode;
 import com.recipe.jamanchu.domain.model.type.UserRole;
@@ -192,8 +193,7 @@ public class UserAccessHandler {
       return ResultResponse.of(ResultCode.EMAIL_NICKNAME_MISMATCH, false);
     }
 
-    UserEntity user = userRepository.findByEmail(email)
-        .orElseThrow(UserNotFoundException::new);
+    UserEntity user = findByEmail(email);
 
     Map<String, Object> responseData = new HashMap<>();
     responseData.put("userId", user.getUserId());
@@ -201,11 +201,10 @@ public class UserAccessHandler {
     return ResultResponse.of(ResultCode.EMAIL_NICKNAME_MATCH, responseData);
   }
 
-  public ResultResponse updatePassword(Long userId, String password) {
-    UserEntity user = userRepository.findByUserId(userId)
-        .orElseThrow(UserNotFoundException::new);
+  public ResultResponse updatePassword(PasswordUpdateDTO passwordUpdateDTO) {
+    UserEntity user = findByUserId(passwordUpdateDTO.getUserId());
 
-    user.updatePassword(passwordEncoder.encode(password));
+    user.updatePassword(passwordEncoder.encode(passwordUpdateDTO.getPassword()));
     saveUser(user);
     return ResultResponse.of(ResultCode.SUCCESS_UPDATE_PASSWORD);
   }

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/entity/UserEntity.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/entity/UserEntity.java
@@ -57,5 +57,9 @@ public class UserEntity extends BaseTimeEntity {
 
   @Column(name = "deletion_scheduled_at")
   private LocalDate deletionScheduledAt;
+
+  public void updatePassword(String password) {
+    this.password = password;
+  }
 }
 

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/model/dto/request/auth/PasswordUpdateDTO.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/model/dto/request/auth/PasswordUpdateDTO.java
@@ -2,11 +2,13 @@ package com.recipe.jamanchu.domain.model.dto.request.auth;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class PasswordUpdateDTO {
 
+  @NotNull(message = "회원 ID가 없습니다.")
   @JsonProperty("userId")
   private Long userId;
 

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/model/dto/request/auth/PasswordUpdateDTO.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/model/dto/request/auth/PasswordUpdateDTO.java
@@ -1,0 +1,21 @@
+package com.recipe.jamanchu.domain.model.dto.request.auth;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class PasswordUpdateDTO {
+
+  @JsonProperty("userId")
+  private Long userId;
+
+  @JsonProperty("password")
+  private String password;
+
+  @JsonCreator
+  public PasswordUpdateDTO(Long userId, String password) {
+    this.userId = userId;
+    this.password = password;
+  }
+}

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/model/type/ResultCode.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/model/type/ResultCode.java
@@ -37,7 +37,11 @@ public enum ResultCode {
   PASSWORD_MATCH(HttpStatus.OK, "비밀번호가 일치 합니다."),
   PASSWORD_MISMATCH(HttpStatus.OK, "비밀번호가 일치하지 않습니다."),
   SUCCESS_RETRIEVE_RECOMMEND_RECIPES(HttpStatus.OK, "추천 레시피 조회 성공"),
-  SUCCESS_GET_ALARM_LIST(HttpStatus.OK, "알림 리스트 조회 성공" );
+  SUCCESS_GET_ALARM_LIST(HttpStatus.OK, "알림 리스트 조회 성공" ),
+  EMAIL_NICKNAME_MATCH(HttpStatus.OK, "비밀번호를 수정할 수 있습니다."),
+  EMAIL_NICKNAME_MISMATCH(HttpStatus.OK, "회원 정보를 다시 확인해주세요."),
+  SUCCESS_UPDATE_PASSWORD(HttpStatus.OK, "비밀번호를 수정했습니다."),
+  ;
 
   private final HttpStatus statusCode;
   private final String message;

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/UserRepository.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/UserRepository.java
@@ -16,6 +16,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
   boolean existsByNickname(String nickname);
 
+  boolean existsByEmailAndNickname(String email, String nickname);
+
   @Query("SELECT u FROM UserEntity u "
       + "WHERE u.email = :email "
       + "AND u.provider IS NULL ")

--- a/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/UserRepository.java
+++ b/jamanchu/module-domain/src/main/java/com/recipe/jamanchu/domain/repository/UserRepository.java
@@ -16,6 +16,11 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
   boolean existsByNickname(String nickname);
 
+  @Query("SELECT COUNT(u) > 0 FROM UserEntity u "
+      + "WHERE u.email = :email "
+      + "AND u.nickname = :nickname "
+      + "AND u.provider IS NULL "
+      + "AND u.deletionScheduledAt IS NULL")
   boolean existsByEmailAndNickname(String email, String nickname);
 
   @Query("SELECT u FROM UserEntity u "


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 로그인 전 비밀번호를 찾기 위한 api 구현
  - /find-password
  - /update-password
- /find-password
  - request로 이메일 주소와 닉네임을 받아 일치하는지를 판단하는 API
    - 카카오로 가입하지 않은 일반회원이어야 하며, 삭제예정 회원이 아니여야 함
    - 일치하는 정보를 받는다면, userId 와 true 값을 프론트에 전달
    - 일치하는 정보를 받지 못했다면, false 값을 프론트에 전달
- /update-password
  - request로 find-password 에서 찾은 userId를 받아서 해당 user의 비밀번호를 업데이트하는 API
  - /find-password 에서 검증이 된 userId를 받기 때문에 새로운 password를 입력받아 업데이트 해주는 역할을 함
  - password 의 길이 등의 검증은 프론트에서 진행
- Test 코드 작성

## 스크린샷

## 주의사항

Closes #156 
