### PR TITLE
[fix] Notify Connection Pool이 마르는 문제 해결

### DIFF
--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/config/AsyncConfig.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.recipe.jamanchu.api.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.concurrent.DelegatingSecurityContextExecutor;
+
+@Configuration
+@EnableAsync(proxyTargetClass = true)
+public class AsyncConfig implements AsyncConfigurer {
+  @Override
+  public Executor getAsyncExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(5);
+    executor.setMaxPoolSize(10);
+    executor.setQueueCapacity(500);
+    executor.setThreadNamePrefix("AsyncThread-");
+    executor.initialize();
+
+    // SecurityContext를 유지하도록 DelegatingSecurityContextExecutor 사용
+    return new DelegatingSecurityContextExecutor(executor);
+  }
+}

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/config/SecurityConfig.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/config/SecurityConfig.java
@@ -45,7 +45,10 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             //swagger ui 허용
             .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-            .requestMatchers("/v3/api-docs/**", "/api/v1/scrape-recipes", "/api/v1/divide",
+            .requestMatchers(
+                "/v3/api-docs/**",
+                "/api/v1/scrape-recipes",
+                "/api/v1/divide",
                 "/swagger-ui/**",
                 "/swagger-ui.html",
                 "/swagger-resources/**").permitAll()

--- a/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/NotifyService.java
+++ b/jamanchu/module-api/src/main/java/com/recipe/jamanchu/api/service/NotifyService.java
@@ -19,4 +19,6 @@ public interface NotifyService {
 
   // 해당 유저의 알림 리스트 반환
   ResultResponse getNotifyList(HttpServletRequest request);
+
+  void checkSubscribers();
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용

기존에는 Async에 대한 내용이 없어서 비동기 처리에 대한 문제 해결

알림 전달 하는 메서드에 Async 적용

스케쥴러를 통해서 알림 연결된 유저에게 20초마다 "Check Connection" 메세지를 전달해서 커넥션 유지

이미 OSIV는 false로 설정되어 있었음


## 문제점

```
Description:

The bean 'notifyServiceImpl' could not be injected because it is a JDK dynamic proxy

The bean is of type 'jdk.proxy2.$Proxy170' and implements:
	com.recipe.jamanchu.api.service.NotifyService
	org.springframework.aop.SpringProxy
	org.springframework.aop.framework.Advised
	org.springframework.core.DecoratingProxy

Expected a bean of type 'com.recipe.jamanchu.api.service.impl.NotifyServiceImpl' which implements:
	com.recipe.jamanchu.api.service.NotifyService


Action:

Consider injecting the bean as one of its interfaces or forcing the use of CGLib-based proxies by setting proxyTargetClass=true on @EnableAsync and/or @EnableCaching.
```

Spring에서 JDK 동적 프로시를 사용하여 생성된 프록시 객체를 사용하고 있기 때문에 발생하는 오류
Spring은 기본적으로 인터페이스 기반의 JDK 동적 프록시를 생성하지만, 코드에서 NotifyServiceImpl 클래스의 구체적인 구현체를 기대하고 있기때문에 발생하는 문제
-> Interface에 메서드를 추가해서 인터페이스를 의존하게 변경해서 문제 

알림 전달 부분에 CompletableFuture를 통해 SseEmitter를 전달하는 경우 Spring Security Context를 태워서 보내도 403 Error가 발생.

## 스크린샷

## 주의사항

Closes #164 